### PR TITLE
fix: create index and alias to make ILM works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
 
     <groupId>io.gravitee.reporter</groupId>
     <artifactId>gravitee-reporter-elasticsearch</artifactId>
-    <version>3.8.4</version>
+    <version>3.8.5</version>
 
     <name>Gravitee.io APIM - Reporter - Elasticsearch</name>
 
     <properties>
         <gravitee-bom.version>1.1</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>3.8.4</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>3.8.5</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>1.22.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>1.10.3</gravitee-node-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
@@ -72,34 +72,40 @@
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
             <version>${gravitee-gateway-api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
             <version>${gravitee-node-api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.reporter</groupId>
             <artifactId>gravitee-reporter-api</artifactId>
             <version>${gravitee-reporter-api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
             <version>${gravitee-policy-api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Used to consume JSON REST services -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/resources/freemarker/es7x/alias/alias.ftl
+++ b/src/main/resources/freemarker/es7x/alias/alias.ftl
@@ -1,0 +1,9 @@
+<@compress single_line=true>
+{
+    "aliases": {
+        "${aliasName}": {
+            "is_write_index": true
+        }
+    }
+}
+</@compress>

--- a/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
@@ -3,6 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
+        <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -3,6 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
@@ -3,6 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
+        <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -3,6 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7110

**Description**

Use new methods introduced with https://github.com/gravitee-io/gravitee-common-elasticsearch/pull/173 to handle alias creation in ILM mode.
A new index with an alias is created if and only if alias does not exist yet.

Also added a missing field in index-templates to make ILM works
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.8.5-7110-fix-ILM-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/3.8.5-7110-fix-ILM-support-SNAPSHOT/gravitee-reporter-elasticsearch-3.8.5-7110-fix-ILM-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
