### PR TITLE
fix: align template api response time type with metrics api response time type

### DIFF
--- a/src/main/resources/freemarker/es5x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es5x/mapping/index-template-request.ftl
@@ -16,7 +16,7 @@
                     "type": "keyword"
                 },
                 "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"

--- a/src/main/resources/freemarker/es5x/mapping/index-template.ftl
+++ b/src/main/resources/freemarker/es5x/mapping/index-template.ftl
@@ -14,7 +14,7 @@
                     "index": false
                 },
                     "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"

--- a/src/main/resources/freemarker/es6x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es6x/mapping/index-template-request.ftl
@@ -17,7 +17,7 @@
                     "type": "keyword"
                 },
                 "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -18,7 +18,7 @@
                     "type": "keyword"
                 },
                 "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7094

**Description**

In the [gravitee-reporter-api metrics class](https://github.com/gravitee-io/gravitee-reporter-api/blob/master/src/main/java/io/gravitee/reporter/api/http/Metrics.java#L33) the api response time is a long.

Now let's imagine you create an API on APIM and link it to an endpoint which send events using SSE. If you keep the stream alive for a time ( in millisecond ) greater than the interger max value you can have an error saying.

To reproduce the bug you'll have to wait 3 weeks before closing your http request or play with the time itself 😛
NB: When this pull request will be merge I'll cherry pick the commit to have the fix on all other versions.

```
17:43:51.806 [vert.x-eventloop-thread-10] [] ERROR i.g.e.client.http.HttpClient - An error occurs while indexing data into ES: indice[gravitee-request-2022.06.09] error[failed to parse field [api-response-time] of type [integer] in document with id '224c62d3-d3ce-4447-8c62-d3d3ceb4471b'. Preview of field's value: '271640000000']
```