### PR TITLE
fix: align template api response time type with metrics api response time type

### DIFF
--- a/src/main/resources/freemarker/es5x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es5x/mapping/index-template-request.ftl
@@ -16,7 +16,7 @@
                     "type": "keyword"
                 },
                 "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"

--- a/src/main/resources/freemarker/es5x/mapping/index-template.ftl
+++ b/src/main/resources/freemarker/es5x/mapping/index-template.ftl
@@ -14,7 +14,7 @@
                     "index": false
                 },
                     "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"

--- a/src/main/resources/freemarker/es6x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es6x/mapping/index-template-request.ftl
@@ -17,7 +17,7 @@
                     "type": "keyword"
                 },
                 "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -18,7 +18,7 @@
                     "type": "keyword"
                 },
                 "api-response-time": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "application": {
                     "type": "keyword"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7094

**Description**

Cherry pick of the commit of this PR:  https://github.com/gravitee-io/gravitee-reporter-elasticsearch/pull/16
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.12.2-fix-api-response-time-type-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/3.12.2-fix-api-response-time-type-master-SNAPSHOT/gravitee-reporter-elasticsearch-3.12.2-fix-api-response-time-type-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
