### PR TITLE
fix: use map iteration style for headers in health and logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>1.1</gravitee-bom.version>
         <gravitee-common-elasticsearch.version>3.12.1</gravitee-common-elasticsearch.version>
-        <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.3</gravitee-gateway-api.version>
         <gravitee-node-api.version>1.10.3</gravitee-node-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>

--- a/src/main/resources/freemarker/es5x/index/health.ftl
+++ b/src/main/resources/freemarker/es5x/index/health.ftl
@@ -27,17 +27,15 @@
             </#if>
             <#if step.getRequest().getHeaders()??>
             ,"headers":{
-            <#list step.getRequest().getHeaders().names() as header>
-                "${header}": [
-                <#list step.getRequest().getHeaders().getAll(header) as value>
-                    <#if value??>
+                <#list step.getRequest().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
                         "${value?j_string}"
                         <#sep>,</#sep>
-                    </#if>
+                    </#list>
+                    ]
+                    <#sep>,</#sep>
                 </#list>
-                ]
-                <#sep>,</#sep>
-            </#list>
             }
             </#if>
         },
@@ -48,13 +46,11 @@
             </#if>
             <#if step.getResponse().getHeaders()??>
             ,"headers":{
-                <#list step.getResponse().getHeaders().names() as header>
-                    "${header}": [
-                    <#list step.getResponse().getHeaders().getAll(header) as value>
-                        <#if value??>
-                            "${value?j_string}"
-                            <#sep>,</#sep>
-                        </#if>
+                <#list step.getResponse().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
+                        "${value?j_string}"
+                        <#sep>,</#sep>
                     </#list>
                     ]
                     <#sep>,</#sep>

--- a/src/main/resources/freemarker/es5x/index/log.ftl
+++ b/src/main/resources/freemarker/es5x/index/log.ftl
@@ -20,9 +20,9 @@
     </#if>
     <#if log.getClientRequest().getHeaders()??>
     ,"headers":{
-      <#list log.getClientRequest().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getClientRequest().getHeaders().getAll(header) as value>
+      <#list log.getClientRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
             "${value?j_string}"
             <#sep>,</#sep>
@@ -41,9 +41,9 @@
     </#if>
     <#if log.getClientResponse().getHeaders()??>
     ,"headers":{
-      <#list log.getClientResponse().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getClientResponse().getHeaders().getAll(header) as value>
+      <#list log.getClientResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
             "${value?j_string}"
             <#sep>,</#sep>

--- a/src/main/resources/freemarker/es6x/index/health.ftl
+++ b/src/main/resources/freemarker/es6x/index/health.ftl
@@ -27,17 +27,15 @@
             </#if>
             <#if step.getRequest().getHeaders()??>
             ,"headers":{
-            <#list step.getRequest().getHeaders().names() as header>
-                "${header}": [
-                <#list step.getRequest().getHeaders().getAll(header) as value>
-                    <#if value??>
+                <#list step.getRequest().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
                         "${value?j_string}"
                         <#sep>,</#sep>
-                    </#if>
+                    </#list>
+                    ]
+                    <#sep>,</#sep>
                 </#list>
-                ]
-                <#sep>,</#sep>
-            </#list>
             }
             </#if>
         },
@@ -48,13 +46,11 @@
             </#if>
             <#if step.getResponse().getHeaders()??>
             ,"headers":{
-                <#list step.getResponse().getHeaders().names() as header>
-                    "${header}": [
-                    <#list step.getResponse().getHeaders().getAll(header) as value>
-                        <#if value??>
-                            "${value?j_string}"
-                            <#sep>,</#sep>
-                        </#if>
+                <#list step.getResponse().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
+                        "${value?j_string}"
+                        <#sep>,</#sep>
                     </#list>
                     ]
                     <#sep>,</#sep>

--- a/src/main/resources/freemarker/es6x/index/log.ftl
+++ b/src/main/resources/freemarker/es6x/index/log.ftl
@@ -12,9 +12,9 @@
     </#if>
     <#if log.getClientRequest().getHeaders()??>
     ,"headers":{
-      <#list log.getClientRequest().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getClientRequest().getHeaders().getAll(header) as value>
+      <#list log.getClientRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
             "${value?j_string}"
             <#sep>,</#sep>
@@ -33,9 +33,9 @@
     </#if>
     <#if log.getClientResponse().getHeaders()??>
     ,"headers":{
-      <#list log.getClientResponse().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getClientResponse().getHeaders().getAll(header) as value>
+      <#list log.getClientResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
             "${value?j_string}"
             <#sep>,</#sep>

--- a/src/main/resources/freemarker/es7x/index/health.ftl
+++ b/src/main/resources/freemarker/es7x/index/health.ftl
@@ -27,17 +27,15 @@
             </#if>
             <#if step.getRequest().getHeaders()??>
             ,"headers":{
-            <#list step.getRequest().getHeaders().names() as header>
-                "${header}": [
-                <#list step.getRequest().getHeaders().getAll(header) as value>
-                    <#if value??>
+                <#list step.getRequest().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
                         "${value?j_string}"
                         <#sep>,</#sep>
-                    </#if>
+                    </#list>
+                    ]
+                    <#sep>,</#sep>
                 </#list>
-                ]
-                <#sep>,</#sep>
-            </#list>
             }
             </#if>
         },
@@ -48,13 +46,11 @@
             </#if>
             <#if step.getResponse().getHeaders()??>
             ,"headers":{
-                <#list step.getResponse().getHeaders().names() as header>
-                    "${header}": [
-                    <#list step.getResponse().getHeaders().getAll(header) as value>
-                        <#if value??>
-                            "${value?j_string}"
-                            <#sep>,</#sep>
-                        </#if>
+                <#list step.getResponse().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
+                        "${value?j_string}"
+                        <#sep>,</#sep>
                     </#list>
                     ]
                     <#sep>,</#sep>

--- a/src/main/resources/freemarker/es7x/index/log.ftl
+++ b/src/main/resources/freemarker/es7x/index/log.ftl
@@ -12,9 +12,9 @@
     </#if>
     <#if log.getClientRequest().getHeaders()??>
     ,"headers":{
-      <#list log.getClientRequest().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getClientRequest().getHeaders().getAll(header) as value>
+      <#list log.getClientRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
             "${value?j_string}"
             <#sep>,</#sep>
@@ -34,7 +34,7 @@
     <#if log.getClientResponse().getHeaders()??>
     ,"headers":{
       <#list log.getClientResponse().getHeaders().names() as header>
-      "${header}": [
+        "${header}": [
         <#list log.getClientResponse().getHeaders().getAll(header) as value>
           <#if value??>
             "${value?j_string}"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7930

**Description**

Rollback the work that has been done for 

- `health` freemarker template in https://github.com/gravitee-io/gravitee-reporter-elasticsearch/commit/d9f1a91a0536533e709fe5d0657a9ade1b80167a
- `logs` freemarker template in https://github.com/gravitee-io/gravitee-reporter-elasticsearch/commit/baa01473610808a8921059fb7a661dffe252c44b

This changed is due to the work on https://github.com/gravitee-io/issues/issues/7812 which changes the implementations of `HttpHeaders` to also implements `MultiMap` (which is a `Map`).
Freemarker detects the object as `instanceof Map` and apply to him a `DefaultMapAdapter`, making impossible to use the methods from `HttpHeaders` in the template.

**Additional context**

Here is a proposal [issue](https://github.com/gravitee-io/issues/issues/7940) aiming to rework the way headers are used by Freemarker.
