### PR TITLE
fix: use map iteration style for headers in logging - missed blocks

### DIFF
--- a/src/main/resources/freemarker/es5x/index/log.ftl
+++ b/src/main/resources/freemarker/es5x/index/log.ftl
@@ -65,9 +65,9 @@
     </#if>
     <#if log.getProxyRequest().getHeaders()??>
     ,"headers":{
-      <#list log.getProxyRequest().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getProxyRequest().getHeaders().getAll(header) as value>
+      <#list log.getProxyRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
           "${value?j_string}"
             <#sep>,</#sep>
@@ -88,9 +88,9 @@
     </#if>
     <#if log.getProxyResponse().getHeaders()??>
     ,"headers":{
-      <#list log.getProxyResponse().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getProxyResponse().getHeaders().getAll(header) as value>
+      <#list log.getProxyResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
           "${value?j_string}"
             <#sep>,</#sep>

--- a/src/main/resources/freemarker/es6x/index/log.ftl
+++ b/src/main/resources/freemarker/es6x/index/log.ftl
@@ -57,9 +57,9 @@
     </#if>
     <#if log.getProxyRequest().getHeaders()??>
     ,"headers":{
-      <#list log.getProxyRequest().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getProxyRequest().getHeaders().getAll(header) as value>
+      <#list log.getProxyRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
           "${value?j_string}"
             <#sep>,</#sep>
@@ -80,9 +80,9 @@
     </#if>
     <#if log.getProxyResponse().getHeaders()??>
     ,"headers":{
-      <#list log.getProxyResponse().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getProxyResponse().getHeaders().getAll(header) as value>
+      <#list log.getProxyResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
           "${value?j_string}"
             <#sep>,</#sep>

--- a/src/main/resources/freemarker/es7x/index/log.ftl
+++ b/src/main/resources/freemarker/es7x/index/log.ftl
@@ -33,9 +33,9 @@
     </#if>
     <#if log.getClientResponse().getHeaders()??>
     ,"headers":{
-      <#list log.getClientResponse().getHeaders().names() as header>
-        "${header}": [
-        <#list log.getClientResponse().getHeaders().getAll(header) as value>
+      <#list log.getClientResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
             "${value?j_string}"
             <#sep>,</#sep>
@@ -57,9 +57,9 @@
     </#if>
     <#if log.getProxyRequest().getHeaders()??>
     ,"headers":{
-      <#list log.getProxyRequest().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getProxyRequest().getHeaders().getAll(header) as value>
+      <#list log.getProxyRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
           "${value?j_string}"
             <#sep>,</#sep>
@@ -80,9 +80,9 @@
     </#if>
     <#if log.getProxyResponse().getHeaders()??>
     ,"headers":{
-      <#list log.getProxyResponse().getHeaders().names() as header>
-      "${header}": [
-        <#list log.getProxyResponse().getHeaders().getAll(header) as value>
+      <#list log.getProxyResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
           <#if value??>
           "${value?j_string}"
             <#sep>,</#sep>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7930


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.12.4-issues-7930-fix-es-headers-reporting-2-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/3.12.4-issues-7930-fix-es-headers-reporting-2-SNAPSHOT/gravitee-reporter-elasticsearch-3.12.4-issues-7930-fix-es-headers-reporting-2-SNAPSHOT.zip)
  <!-- Version placeholder end -->
