### PR TITLE
Add ES 8 support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,10 +54,11 @@ Then you can activate the ILM feature by adding these settings in the gravitee.y
 IMPORTANT: To use ILM feature you need to use at least version 3.8.5 (for APIM 3.10.x) or 3.12.1 of the plugin (for APIM 3.15.x and upper).
 
 == Testing
-By default, unit tests are run with a TestContainer version of ElasticSearch 7.17.7, but sometimes it can be useful to run them against other version of ElasticSearch.
+By default, unit tests are run with a TestContainer version of ElasticSearch 8.5.2, but sometimes it can be useful to run them against other version of ElasticSearch.
 To do so you can use the following commands:
 
 * ES 5.x: `mvn clean test -Delasticsearch.version=5.6.16`
 * ES 6.x: `mvn clean test -Delasticsearch.version=6.8.23`
-* ES 7.x: `mvn clean test -Delasticsearch.version=7.17.7` (Default)
+* ES 7.x: `mvn clean test -Delasticsearch.version=7.17.7`
+* ES 8.x: `mvn clean test -Delasticsearch.version=8.5.2` (Default)
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
 
     <groupId>io.gravitee.reporter</groupId>
     <artifactId>gravitee-reporter-elasticsearch</artifactId>
-    <version>4.1.0-alpha.7</version>
+    <version>4.1.0-es8-support-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Reporter - Elasticsearch</name>
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>4.1.0-alpha.7</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.1.0-es8-support-SNAPSHOT</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>2.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-node-api.version>2.0.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>4.1.0-es8-support-SNAPSHOT</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.1.0-alpha.8</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>2.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-node-api.version>2.0.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/src/main/java/io/gravitee/reporter/elasticsearch/BeanRegister.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/BeanRegister.java
@@ -62,6 +62,8 @@ public class BeanRegister {
                 return new Elastic6xBeanRegistrer();
             case 7:
                 return new Elastic7xBeanRegistrer();
+            case 8:
+                return new Elastic8xBeanRegistrer();
             default:
                 return null;
         }

--- a/src/main/java/io/gravitee/reporter/elasticsearch/indexer/es8/ES8BulkIndexer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/indexer/es8/ES8BulkIndexer.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.indexer.es8;
+
+import io.gravitee.reporter.elasticsearch.indexer.BulkIndexer;
+import io.vertx.core.buffer.Buffer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Map;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ES8BulkIndexer extends BulkIndexer {
+
+    @Override
+    protected Buffer generateData(String templateName, Map<String, Object> data) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            freeMarkerComponent.generateFromTemplate("/es8x/index/" + templateName, data, new OutputStreamWriter(baos));
+
+            return Buffer.buffer(baos.toByteArray());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es8/ES8IndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es8/ES8IndexPreparer.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.mapping.es8;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.reporter.elasticsearch.mapping.PerTypeIndexPreparer;
+import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.functions.Function;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ES8IndexPreparer extends PerTypeIndexPreparer {
+
+    /**
+     * Configuration of pipelineConfiguration
+     */
+    @Autowired
+    private PipelineConfiguration pipelineConfiguration;
+
+    @Override
+    public Completable prepare() {
+        return indexMapping().andThen(pipeline());
+    }
+
+    @Override
+    protected Function<Type, CompletableSource> indexTypeMapper() {
+        return type -> {
+            final String typeName = type.getType();
+            final String templateName = configuration.getIndexName() + '-' + typeName;
+            final String aliasName = configuration.getIndexName() + '-' + typeName;
+
+            logger.debug("Trying to put template mapping for type[{}] name[{}]", typeName, templateName);
+
+            Map<String, Object> data = getTemplateData();
+            data.put("indexName", configuration.getIndexName() + '-' + typeName);
+
+            final String template = freeMarkerComponent.generateFromTemplate("/es8x/mapping/index-template-" + typeName + ".ftl", data);
+
+            final Completable templateCreationCompletable = client.putTemplate(templateName, template);
+            if (configuration.isIlmManagedIndex()) {
+                return templateCreationCompletable.andThen(ensureAlias(aliasName));
+            }
+            return templateCreationCompletable;
+        };
+    }
+
+    private Completable ensureAlias(String aliasName) {
+        final String aliasTemplate = freeMarkerComponent.generateFromTemplate(
+            "/es8x/alias/alias.ftl",
+            Collections.singletonMap("aliasName", aliasName)
+        );
+
+        return client
+            .getAlias(aliasName)
+            .switchIfEmpty(client.createIndexWithAlias(aliasName + "-000001", aliasTemplate).toMaybe())
+            .ignoreElement();
+    }
+
+    private Completable pipeline() {
+        String pipelineTemplate = pipelineConfiguration.createPipeline();
+
+        if (pipelineTemplate != null && pipelineConfiguration.getPipelineName() != null) {
+            return client
+                .putPipeline(pipelineConfiguration.getPipelineName(), pipelineTemplate)
+                .doOnComplete(() -> pipelineConfiguration.valid());
+        }
+
+        return Completable.complete();
+    }
+}

--- a/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic8xBeanRegistrer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/spring/context/Elastic8xBeanRegistrer.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.spring.context;
+
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.reporter.elasticsearch.indexer.AbstractIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.es8.ES8BulkIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.name.AbstractIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
+import io.gravitee.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class Elastic8xBeanRegistrer extends AbstractElasticBeanRegistrer {
+
+    @Override
+    protected Class<? extends AbstractIndexer> getIndexerClass() {
+        return ES8BulkIndexer.class;
+    }
+
+    @Override
+    protected Class<? extends AbstractIndexPreparer> getIndexPreparerClass(ReporterConfiguration configuration) {
+        return ES8IndexPreparer.class;
+    }
+
+    @Override
+    protected Class<? extends AbstractIndexNameGenerator> getIndexNameGeneratorClass(ReporterConfiguration configuration) {
+        return configuration.isIlmManagedIndex() ? PerTypeIndexNameGenerator.class : PerTypeAndDateIndexNameGenerator.class;
+    }
+}

--- a/src/test/java/io/gravitee/reporter/elasticsearch/BeanRegisterTest.java
+++ b/src/test/java/io/gravitee/reporter/elasticsearch/BeanRegisterTest.java
@@ -23,6 +23,7 @@ import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.reporter.elasticsearch.indexer.es5.ES5BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es6.ES6BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.es7.ES7BulkIndexer;
+import io.gravitee.reporter.elasticsearch.indexer.es8.ES8BulkIndexer;
 import io.gravitee.reporter.elasticsearch.indexer.name.MultiTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeAndDateIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.indexer.name.PerTypeIndexNameGenerator;
@@ -30,6 +31,7 @@ import io.gravitee.reporter.elasticsearch.mapping.es5.ES5MultiTypeIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es5.ES5PerTypeIndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es6.ES6IndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+import io.gravitee.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -144,6 +146,34 @@ class BeanRegisterTest {
     }
 
     @Nested
+    class ElasticSearch8 {
+
+        @Test
+        void should_instantiate_beans_for_elasticsearch_8_daily_mode() {
+            var reporterConfiguration = new ReporterConfiguration();
+            reporterConfiguration.setIndexMode("daily");
+
+            register.registerBeans(elasticsearchInfo("8.5.2"), reporterConfiguration);
+
+            assertThat(applicationContext.getBean("indexer")).isInstanceOf(ES8BulkIndexer.class);
+            assertThat(applicationContext.getBean("indexPreparer")).isInstanceOf(ES8IndexPreparer.class);
+            assertThat(applicationContext.getBean("indexNameGenerator")).isInstanceOf(PerTypeAndDateIndexNameGenerator.class);
+        }
+
+        @Test
+        void should_instantiate_beans_for_elasticsearch_8_ilm_mode() {
+            var reporterConfiguration = new ReporterConfiguration();
+            reporterConfiguration.setIndexMode("ilm");
+
+            register.registerBeans(elasticsearchInfo("8.5.2"), reporterConfiguration);
+
+            assertThat(applicationContext.getBean("indexer")).isInstanceOf(ES8BulkIndexer.class);
+            assertThat(applicationContext.getBean("indexPreparer")).isInstanceOf(ES8IndexPreparer.class);
+            assertThat(applicationContext.getBean("indexNameGenerator")).isInstanceOf(PerTypeIndexNameGenerator.class);
+        }
+    }
+
+    @Nested
     class OpenSearch1 {
 
         @Test
@@ -172,7 +202,7 @@ class BeanRegisterTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = { "elastic:8.0.0", "opensearch:2.12.7" }, delimiter = ':')
+    @CsvSource(value = { "opensearch:2.12.7" }, delimiter = ':')
     void should_ignore_unsupported_version(String distribution, String version) {
         register.registerBeans(elasticsearchInfo(distribution, version), new ReporterConfiguration());
 

--- a/src/test/java/io/gravitee/reporter/elasticsearch/IntegrationTestConfiguration.java
+++ b/src/test/java/io/gravitee/reporter/elasticsearch/IntegrationTestConfiguration.java
@@ -34,7 +34,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 @Import(UnitTestConfiguration.class)
 public class IntegrationTestConfiguration {
 
-    public static final String ELASTICSEARCH_DEFAULT_VERSION = "7.17.8";
+    public static final String ELASTICSEARCH_DEFAULT_VERSION = "8.5.2";
     public static final String CLUSTER_NAME = "gravitee_test";
 
     @Value("${elasticsearch.version:" + ELASTICSEARCH_DEFAULT_VERSION + "}")
@@ -55,6 +55,9 @@ public class IntegrationTestConfiguration {
             "docker.elastic.co/elasticsearch/elasticsearch:" + elasticsearchVersion
         );
         elasticsearchContainer.withEnv("cluster.name", CLUSTER_NAME);
+        if (elasticsearchVersion.startsWith("8")) {
+            elasticsearchContainer.withEnv("xpack.security.enabled", "false");
+        }
         elasticsearchContainer.start();
         return elasticsearchContainer;
     }

--- a/src/test/java/io/gravitee/reporter/elasticsearch/spring/IndexNameGeneratorRegistrationTest.java
+++ b/src/test/java/io/gravitee/reporter/elasticsearch/spring/IndexNameGeneratorRegistrationTest.java
@@ -78,6 +78,9 @@ public class IndexNameGeneratorRegistrationTest {
         if (elasticsearchVersion.startsWith("7")) {
             configuration.setIndexMode("daily");
         }
+        if (elasticsearchVersion.startsWith("8")) {
+            configuration.setIndexMode("daily");
+        }
         reporter.start();
         IndexNameGenerator indexNameGenerator = (IndexNameGenerator) applicationContext.getBean("indexNameGenerator");
         assertThat(indexNameGenerator.getClass()).isEqualTo(PerTypeAndDateIndexNameGenerator.class);
@@ -97,6 +100,9 @@ public class IndexNameGeneratorRegistrationTest {
         if (elasticsearchVersion.startsWith("7")) {
             configuration.setIndexMode("ilm");
         }
+        if (elasticsearchVersion.startsWith("8")) {
+            configuration.setIndexMode("ilm");
+        }
         reporter.start();
 
         IndexNameGenerator indexNameGenerator = (IndexNameGenerator) applicationContext.getBean("indexNameGenerator");
@@ -111,6 +117,10 @@ public class IndexNameGeneratorRegistrationTest {
             assertThat(generatedName).isEqualTo("gravitee-log");
         }
         if (elasticsearchVersion.startsWith("7")) {
+            assertThat(indexNameGenerator.getClass()).isEqualTo(PerTypeIndexNameGenerator.class);
+            assertThat(generatedName).isEqualTo("gravitee-log");
+        }
+        if (elasticsearchVersion.startsWith("8")) {
             assertThat(indexNameGenerator.getClass()).isEqualTo(PerTypeIndexNameGenerator.class);
             assertThat(generatedName).isEqualTo("gravitee-log");
         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-427

**Description**

Add ES 8 support
Depends on https://github.com/gravitee-io/gravitee-common-elasticsearch/pull/181
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-es8-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/4.1.0-es8-support-SNAPSHOT/gravitee-reporter-elasticsearch-4.1.0-es8-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
