### PR TITLE
Rename path to path info in v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>4.1.0-alpha.3</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.1.0-alpha.4</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>2.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-node-api.version>2.0.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.2</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.3</gravitee-reporter-api.version>
         <commons-validator.version>1.7</commons-validator.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <log4j-core.version>2.19.0</log4j-core.version>

--- a/src/main/java/io/gravitee/reporter/elasticsearch/indexer/AbstractIndexer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/indexer/AbstractIndexer.java
@@ -192,7 +192,7 @@ public abstract class AbstractIndexer implements Indexer {
         data.put("requestContentLength", metrics.getRequestContentLength() >= 0 ? metrics.getRequestContentLength() : null);
         data.put("responseContentLength", metrics.getResponseContentLength() >= 0 ? metrics.getResponseContentLength() : null);
 
-        return generateData("metrics-v4.ftl", data);
+        return generateData("v4-metrics.ftl", data);
     }
 
     /**
@@ -213,7 +213,7 @@ public abstract class AbstractIndexer implements Indexer {
         data.put("errorCount", metrics.getErrorCount() >= 0 ? metrics.getErrorCount() : null);
         data.put("gatewayLatencyMs", metrics.getGatewayLatencyMs() >= 0 ? metrics.getGatewayLatencyMs() : null);
 
-        return generateData("message-metrics-v4.ftl", data);
+        return generateData("v4-message-metrics.ftl", data);
     }
 
     /**
@@ -248,7 +248,7 @@ public abstract class AbstractIndexer implements Indexer {
         data.put(Fields.SPECIAL_TIMESTAMP, dtf.format(log.timestamp()));
         data.put("log", log);
 
-        return generateData("log-v4.ftl", data);
+        return generateData("v4-log.ftl", data);
     }
 
     /**
@@ -264,7 +264,7 @@ public abstract class AbstractIndexer implements Indexer {
         data.put(Fields.SPECIAL_TIMESTAMP, dtf.format(log.timestamp()));
         data.put("log", log);
 
-        return generateData("message-log-v4.ftl", data);
+        return generateData("v4-message-log.ftl", data);
     }
 
     /**

--- a/src/main/java/io/gravitee/reporter/elasticsearch/indexer/name/AbstractPerTypeIndexNameGenerator.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/indexer/name/AbstractPerTypeIndexNameGenerator.java
@@ -42,13 +42,13 @@ public abstract class AbstractPerTypeIndexNameGenerator extends AbstractIndexNam
         } else if (reportable instanceof EndpointStatus) {
             type = Type.HEALTH_CHECK.getType();
         } else if (reportable instanceof io.gravitee.reporter.api.v4.metric.Metrics) {
-            type = Type.METRICS_V4.getType();
+            type = Type.V4_METRICS.getType();
         } else if (reportable instanceof io.gravitee.reporter.api.v4.log.Log) {
-            type = Type.LOG_V4.getType();
+            type = Type.V4_LOG.getType();
         } else if (reportable instanceof io.gravitee.reporter.api.v4.metric.MessageMetrics) {
-            type = Type.MESSAGE_METRICS_V4.getType();
+            type = Type.V4_MESSAGE_METRICS.getType();
         } else if (reportable instanceof io.gravitee.reporter.api.v4.log.MessageLog) {
-            type = Type.MESSAGE_LOG_V4.getType();
+            type = Type.V4_MESSAGE_LOG.getType();
         }
 
         return generate(type, reportable.timestamp());


### PR DESCRIPTION
**Issue**

[APIM-490](https://gravitee.atlassian.net/browse/APIM-490)

**Description**

Rename path to pathInfo
Rename index to avoid issue with pattern matching

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->


[APIM-490]: https://gravitee.atlassian.net/browse/APIM-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-rename-path-to-path-info-in-v4-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/4.1.0-rename-path-to-path-info-in-v4-SNAPSHOT/gravitee-reporter-elasticsearch-4.1.0-rename-path-to-path-info-in-v4-SNAPSHOT.zip)
  <!-- Version placeholder end -->
