### PR TITLE
fix: bump common elasticsearch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
 
     <groupId>io.gravitee.reporter</groupId>
     <artifactId>gravitee-reporter-elasticsearch</artifactId>
-    <version>4.1.0-alpha.4</version>
+    <version>4.1.0-alpha.5</version>
 
     <name>Gravitee.io APIM - Reporter - Elasticsearch</name>
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>4.1.0-alpha.4</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.1.0-alpha.5</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>2.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-node-api.version>2.0.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION

**Description**

Bump common ES version

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-bump-common-elasticsearch-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/4.1.0-bump-common-elasticsearch-version-SNAPSHOT/gravitee-reporter-elasticsearch-4.1.0-bump-common-elasticsearch-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
