### PR TITLE
fix: bump common elasticsearch version to 4.1.0-alpha.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>4.1.0-alpha.5</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.1.0-alpha.6</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>2.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-node-api.version>2.0.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-490

**Description**

Use latest alpha version

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-bump-common-es-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/4.1.0-bump-common-es-version-SNAPSHOT/gravitee-reporter-elasticsearch-4.1.0-bump-common-es-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
