### PR TITLE
fix: bump common elasticsearch version to get new error status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,17 +27,17 @@
 
     <groupId>io.gravitee.reporter</groupId>
     <artifactId>gravitee-reporter-elasticsearch</artifactId>
-    <version>4.1.0-alpha.6</version>
+    <version>4.1.0-apim-490-add-error-metric-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Reporter - Elasticsearch</name>
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common-elasticsearch.version>4.1.0-alpha.6</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.1.0-alpha.7</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>2.1.0-alpha.7</gravitee-gateway-api.version>
         <gravitee-node-api.version>2.0.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.3</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <commons-validator.version>1.7</commons-validator.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <log4j-core.version>2.19.0</log4j-core.version>


### PR DESCRIPTION
Description

Adding error status on message metrics.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-apim-490-add-error-metric-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/4.1.0-apim-490-add-error-metric-SNAPSHOT/gravitee-reporter-elasticsearch-4.1.0-apim-490-add-error-metric-SNAPSHOT.zip)
  <!-- Version placeholder end -->
