### PR TITLE
fix: read pem certs and keys as a list for ElasticSearch configuration

### DIFF
--- a/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
@@ -104,13 +104,11 @@ public class ReporterConfiguration {
     /**
      * Elasticsearch ssl pem certs paths
      */
-    @Value("${reporters.elasticsearch.ssl.keystore.certs}")
     private List<String> sslPemCerts;
 
     /**
      * Elasticsearch ssl pem keys paths
      */
-    @Value("${reporters.elasticsearch.ssl.keystore.keys}")
     private List<String> sslPemKeys;
 
     /**
@@ -310,6 +308,10 @@ public class ReporterConfiguration {
     }
 
     public List<String> getSslPemCerts() {
+        if (sslPemCerts == null) {
+            sslPemCerts = readPropertyAsList("reporters.elasticsearch.ssl.keystore.certs");
+        }
+
         return sslPemCerts;
     }
 
@@ -318,6 +320,10 @@ public class ReporterConfiguration {
     }
 
     public List<String> getSslPemKeys() {
+        if (sslPemKeys == null) {
+            sslPemKeys = readPropertyAsList("reporters.elasticsearch.ssl.keystore.keys");
+        }
+
         return sslPemKeys;
     }
 
@@ -509,5 +515,24 @@ public class ReporterConfiguration {
 
     public boolean isIlmManagedIndex() {
         return "ilm".equalsIgnoreCase(indexMode);
+    }
+
+    private List<String> readPropertyAsList(String property) {
+        String key = String.format("%s[%s]", property, 0);
+        List<String> properties = new ArrayList<>();
+
+        while (environment.containsProperty(key)) {
+            String p = environment.getProperty(key);
+            properties.add(p);
+
+            key = String.format("%s[%s]", property, properties.size());
+        }
+
+        // fallback to single value style for backward compatibility
+        if (properties.isEmpty()) {
+            properties.add(environment.getProperty(property));
+        }
+
+        return properties;
     }
 }


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-2575
(cherry picked from commit 3de5958b2e9f484a8b238db9f1f58111932610b9)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.12.6-apim-2575-es-keystore-config-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/3.12.6-apim-2575-es-keystore-config-SNAPSHOT/gravitee-reporter-elasticsearch-3.12.6-apim-2575-es-keystore-config-SNAPSHOT.zip)
  <!-- Version placeholder end -->
