### PR TITLE
fix: move reporter common dependency scope to compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
             <groupId>io.gravitee.reporter</groupId>
             <artifactId>gravitee-reporter-common</artifactId>
             <version>${gravitee-reporter-common.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-fix-common-dependency-scope-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.0.1-fix-common-dependency-scope-SNAPSHOT/gravitee-reporter-elasticsearch-5.0.1-fix-common-dependency-scope-SNAPSHOT.zip)
  <!-- Version placeholder end -->
