### PR TITLE
fix: add ingest pipelines plugins template

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,9 @@
 
     <properties>
         <gravitee-bom.version>6.0.4</gravitee-bom.version>
-        <gravitee-reporter-common.version>1.0.0</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>4.1.0</gravitee-common-elasticsearch.version>
+        <gravitee-common.version>3.3.2</gravitee-common.version>
+        <gravitee-reporter-common.version>1.0.3</gravitee-reporter-common.version>
+        <gravitee-common-elasticsearch.version>5.0.1</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.1.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.1.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
@@ -75,6 +76,14 @@
         </dependency>
 
         <!-- Gravitee internal dependencies -->
+
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>

--- a/src/main/java/io/gravitee/reporter/elasticsearch/config/PipelineConfiguration.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/config/PipelineConfiguration.java
@@ -17,7 +17,7 @@ package io.gravitee.reporter.elasticsearch.config;
 
 import static java.util.stream.Collectors.toSet;
 
-import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
+import io.gravitee.common.templating.FreeMarkerComponent;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/AbstractIndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/AbstractIndexPreparer.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.reporter.elasticsearch.mapping;
 
+import io.gravitee.common.templating.FreeMarkerComponent;
 import io.gravitee.elasticsearch.client.Client;
-import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
 import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es7/ES7IndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es7/ES7IndexPreparer.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.reporter.elasticsearch.mapping.es7;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
 import io.gravitee.reporter.elasticsearch.mapping.PerTypeIndexPreparer;

--- a/src/main/java/io/gravitee/reporter/elasticsearch/spring/ElasticsearchReporterConfiguration.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/spring/ElasticsearchReporterConfiguration.java
@@ -15,12 +15,14 @@
  */
 package io.gravitee.reporter.elasticsearch.spring;
 
+import io.gravitee.common.templating.FreeMarkerComponent;
 import io.gravitee.elasticsearch.client.Client;
 import io.gravitee.elasticsearch.client.http.*;
-import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
 import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
 import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
 import io.vertx.rxjava3.core.Vertx;
+import java.nio.file.Path;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -83,8 +85,15 @@ public class ElasticsearchReporterConfiguration {
     }
 
     @Bean
-    public FreeMarkerComponent freeMarkerComponent() {
-        return new FreeMarkerComponent();
+    public FreeMarkerComponent freeMarkerComponent(
+        @Value("${reporters.elasticsearch.template_mapping.path:#{null}}") String templateMappingPath
+    ) {
+        return FreeMarkerComponent
+            .builder()
+            .path(templateMappingPath != null ? Path.of(templateMappingPath) : null)
+            .classLoader(getClass().getClassLoader())
+            .classLoaderTemplateBase("freemarker")
+            .build();
     }
 
     @Bean

--- a/src/main/resources/freemarker/geoip.ftl
+++ b/src/main/resources/freemarker/geoip.ftl
@@ -1,0 +1,35 @@
+<@compress single_line=true>
+{
+  "geoip" : {
+    "field" : "remote-address"
+  }
+},
+{
+  "set": {
+      "field": "geoip.city_name",
+      "value": "Unknown",
+      "override": false
+   }
+},
+{
+  "set": {
+      "field": "geoip.continent_name",
+      "value": "Unknown",
+      "override": false
+   }
+},
+{
+    "set": {
+        "field": "geoip.country_iso_code",
+        "value": "Unknown",
+        "override": false
+    }
+},
+{
+  "set": {
+    "field": "geoip.region_name",
+    "value": "Unknown",
+    "override": false
+  }
+}
+</@compress>

--- a/src/main/resources/freemarker/gravitee.ftl
+++ b/src/main/resources/freemarker/gravitee.ftl
@@ -1,0 +1,8 @@
+<@compress single_line=true>
+    {
+        "gravitee-elasticsearch-ingest-plugin" : {
+            "apiField" : "api",
+            "applicationField" : "application"
+        }
+    }
+</@compress>

--- a/src/main/resources/freemarker/pipeline.ftl
+++ b/src/main/resources/freemarker/pipeline.ftl
@@ -1,0 +1,8 @@
+<@compress single_line=true>
+{
+  "description" : "Gravitee pipeline",
+  "processors" : [
+    ${processors}
+  ]
+}
+</@compress>

--- a/src/main/resources/freemarker/user_agent.ftl
+++ b/src/main/resources/freemarker/user_agent.ftl
@@ -1,0 +1,29 @@
+<@compress single_line=true>
+{
+  "user_agent" : {
+    <#if userAgentRegexFile??>"regex_file": "${userAgentRegexFile}",</#if>
+    "field": "user-agent"
+  }
+},
+{
+  "set": {
+      "field": "user_agent.name",
+      "value": "Unknown",
+      "override": false
+   }
+},
+{
+  "set": {
+      "field": "user_agent.os_name",
+      "value": "{{user_agent.os.name}}",
+      "override": false
+   }
+},
+{
+  "set": {
+      "field": "user_agent.os_name",
+      "value": "Unknown",
+      "override": false
+   }
+}
+</@compress>

--- a/src/test/java/io/gravitee/reporter/elasticsearch/config/PipelineConfigurationTest.java
+++ b/src/test/java/io/gravitee/reporter/elasticsearch/config/PipelineConfigurationTest.java
@@ -17,7 +17,7 @@ package io.gravitee.reporter.elasticsearch.config;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
+import io.gravitee.common.templating.FreeMarkerComponent;
 import io.gravitee.reporter.elasticsearch.UnitTestConfiguration;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -18,22 +18,14 @@
 
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <logger name="io.gravitee" level="ERROR" />
-    <logger name="org.springframework" level="ERROR" additivity="false"/>
-    <logger name="org.eclipse.jetty" level="ERROR" additivity="false"/>
-    <logger name="org.apache.http" level="ERROR" additivity="false"/>
+    <logger name="io.gravitee" level="DEBUG" />
 
-    <!-- Strictly speaking, the level attribute is not necessary since -->
-    <!-- the level of the root level is set to DEBUG by default.       -->
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
-
 </configuration>


### PR DESCRIPTION
This has gone unnoticed in the previous version because the common-elasticsearch version was not bumped.

This revision adds the pipeline templates and bumpts common-elasticsearch as well as reporter-common in order to get the freemarker component able to read templates from a parent class loader.

see https://github.com/gravitee-io/gravitee-reporter-common/pull/4

☝️ This should be merged before and this should be amend to bump to the actual reporter-common version

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.2-fix-common-elasticsearch-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.0.2-fix-common-elasticsearch-version-SNAPSHOT/gravitee-reporter-elasticsearch-5.0.2-fix-common-elasticsearch-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
