### PR TITLE
fix: bump gravitee-reporter-common to fix espace issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>6.0.4</gravitee-bom.version>
         <gravitee-common.version>3.3.2</gravitee-common.version>
-        <gravitee-reporter-common.version>1.0.3</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.0.4</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.0.1</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.1.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.1.0</gravitee-node-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3180

**Description**

Following this [PR](https://github.com/gravitee-io/gravitee-reporter-common/pull/9)
the new version of this reporter will fix the problem in APIM  4.2

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.3-APIM-3180-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.0.3-APIM-3180-SNAPSHOT/gravitee-reporter-elasticsearch-5.0.3-APIM-3180-SNAPSHOT.zip)
  <!-- Version placeholder end -->
