### PR TITLE
feat: use index template instead of legacy template in ES8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <gravitee-bom.version>6.0.4</gravitee-bom.version>
         <gravitee-common.version>3.3.2</gravitee-common.version>
         <gravitee-reporter-common.version>1.0.4</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>5.0.1</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.1.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.1.0</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es8/ES8IndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es8/ES8IndexPreparer.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.reporter.elasticsearch.mapping.es8;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
 import io.gravitee.reporter.elasticsearch.mapping.PerTypeIndexPreparer;
@@ -56,7 +55,7 @@ public class ES8IndexPreparer extends PerTypeIndexPreparer {
 
             final String template = freeMarkerComponent.generateFromTemplate("/es8x/mapping/index-template-" + typeName + ".ftl", data);
 
-            final Completable templateCreationCompletable = client.putTemplate(templateName, template);
+            final Completable templateCreationCompletable = client.putIndexTemplate(templateName, template);
             if (configuration.isIlmManagedIndex()) {
                 return templateCreationCompletable.andThen(ensureAlias(aliasName));
             }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
@@ -1,15 +1,16 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-        <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
+            <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+        },
+        "mappings": {
             "properties": {
                 "api": {
                     "type": "keyword"
@@ -43,5 +44,6 @@
                     "index": false
                 }
             }
+        }
     }
 }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
@@ -1,28 +1,29 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if !(extendedSettingsTemplate.analysis)??>,
-        "analysis": {
-            "analyzer": {
-                "gravitee_body_analyzer": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": [
-                        "lowercase"
-                    ]
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if !(extendedSettingsTemplate.analysis)??>,
+            "analysis": {
+                "analyzer": {
+                    "gravitee_body_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": [
+                            "lowercase"
+                        ]
+                    }
                 }
             }
-        }
-        </#if>
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
+            </#if>
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+        },
+        "mappings": {
             "properties": {
                 "@timestamp": {
                     "type": "date"
@@ -83,5 +84,6 @@
                     }
                 }
             }
+        }
     }
 }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
@@ -1,15 +1,16 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-        <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
+            <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+        },
+        "mappings": {
             "properties": {
                 "os": {
                     "properties": {
@@ -39,5 +40,6 @@
                     "type": "keyword"
                 }
             }
+        }
     }
 }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -1,15 +1,16 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+        },
+        "mappings": {
             "properties": {
                 "@timestamp": {
                     "type": "date"
@@ -180,5 +181,6 @@
                     }
                 }
             ]
+        }
     }
 }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
@@ -1,93 +1,95 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if !(extendedSettingsTemplate.analysis)??>,
-        "analysis": {
-            "analyzer": {
-                "gravitee_body_analyzer": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": [
-                        "lowercase"
-                    ]
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if !(extendedSettingsTemplate.analysis)??>,
+            "analysis": {
+                "analyzer": {
+                    "gravitee_body_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": [
+                            "lowercase"
+                        ]
+                    }
                 }
             }
-        }
-        </#if>
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
-        "properties": {
-            "@timestamp": {
-                "type": "date"
-            },
-            "api-id": {
-                "type": "keyword"
-            },
-            "request-id": {
-                "type": "keyword"
-            },
-            "client-identifier": {
-                "type": "keyword"
-            },
-            "request-ended": {
-                "type": "boolean"
-            },
-            "entrypoint-request": {
-                "type": "object",
-                "properties": {
-                    "body":{
-                        "type": "text",
-                        "analyzer": "gravitee_body_analyzer"
-                    },
-                    "headers":  {
-                       "enabled":  false,
-                       "type": "object"
-                   }
-                }
-            },
-            "entrypoint-response": {
-                "type": "object",
-                "properties": {
-                    "body":{
-                        "type": "text",
-                        "analyzer": "gravitee_body_analyzer"
-                    },
-                    "headers":  {
-                       "enabled":  false,
-                       "type": "object"
-                   }
-                }
-            },
-            "endpoint-request": {
-                "type": "object",
-                "properties": {
-                    "body":{
-                        "type": "text",
-                        "analyzer": "gravitee_body_analyzer"
-                    },
-                    "headers":  {
-                       "enabled":  false,
-                       "type": "object"
-                   }
-                }
-            },
-            "endpoint-response": {
-                "type": "object",
-                "properties": {
-                    "body":{
-                        "type": "text",
-                        "analyzer": "gravitee_body_analyzer"
-                    },
-                    "headers": {
-                        "enabled":  false,
-                        "type": "object"
+            </#if>
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+        },
+        "mappings": {
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api-id": {
+                    "type": "keyword"
+                },
+                "request-id": {
+                    "type": "keyword"
+                },
+                "client-identifier": {
+                    "type": "keyword"
+                },
+                "request-ended": {
+                    "type": "boolean"
+                },
+                "entrypoint-request": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "entrypoint-response": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "endpoint-request": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "endpoint-response": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers": {
+                            "enabled":  false,
+                            "type": "object"
+                        }
                     }
                 }
             }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
@@ -1,76 +1,78 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if !(extendedSettingsTemplate.analysis)??>,
-        "analysis": {
-            "analyzer": {
-                "gravitee_body_analyzer": {
-                    "type": "custom",
-                    "tokenizer": "whitespace",
-                    "filter": [
-                        "lowercase"
-                    ]
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if !(extendedSettingsTemplate.analysis)??>,
+            "analysis": {
+                "analyzer": {
+                    "gravitee_body_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "whitespace",
+                        "filter": [
+                            "lowercase"
+                        ]
+                    }
                 }
             }
-        }
-        </#if>
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
-        "properties": {
-            "@timestamp": {
-                "type": "date"
-            },
-            "api-id": {
-                "type": "keyword"
-            },
-            "request-id": {
-                "type": "keyword"
-            },
-            "client-identifier": {
-                "type": "keyword"
-            },
-            "correlation-id": {
-                "type": "keyword"
-            },
-            "parent-correlation-id": {
-                "type": "keyword"
-            },
-            "operation": {
-                "type": "keyword"
-            },
-            "connector-type": {
-                "type": "keyword"
-            },
-            "connector-id": {
-                "type": "keyword"
-            },
-            "message": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "keyword"
-                    },
-                    "payload":{
-                        "type": "text",
-                        "analyzer": "gravitee_body_analyzer"
-                    },
-                    "headers":{
-                        "enabled": false,
-                        "type": "object"
-                    },
-                    "metadata":  {
-                       "enabled": false,
-                       "type": "object"
-                    },
-                    "error":  {
-                        "type": "boolean"
+            </#if>
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+        },
+        "mappings": {
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api-id": {
+                    "type": "keyword"
+                },
+                "request-id": {
+                    "type": "keyword"
+                },
+                "client-identifier": {
+                    "type": "keyword"
+                },
+                "correlation-id": {
+                    "type": "keyword"
+                },
+                "parent-correlation-id": {
+                    "type": "keyword"
+                },
+                "operation": {
+                    "type": "keyword"
+                },
+                "connector-type": {
+                    "type": "keyword"
+                },
+                "connector-id": {
+                    "type": "keyword"
+                },
+                "message": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "keyword"
+                        },
+                        "payload":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":{
+                            "enabled": false,
+                            "type": "object"
+                        },
+                        "metadata":  {
+                           "enabled": false,
+                           "type": "object"
+                        },
+                        "error":  {
+                            "type": "boolean"
+                        }
                     }
                 }
             }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
@@ -1,73 +1,75 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
-        "properties": {
-            "gateway": {
-                "type": "keyword"
-            },
-            "@timestamp": {
-                "type": "date"
-            },
-            "api-id": {
-                "type": "keyword"
-            },
-            "request-id": {
-                "type": "keyword"
-            },
-            "client-identifier": {
-                "type": "keyword"
-            },
-            "correlation-id": {
-                "type": "keyword"
-            },
-            "parent-correlation-id": {
-                "type": "keyword"
-            },
-            "operation": {
-                "type": "keyword"
-            },
-            "connector-type": {
-                "type": "keyword"
-            },
-            "connector-id": {
-                "type": "keyword"
-            },
-            "content-length": {
-                "type": "integer"
-            },
-            "count": {
-                "type": "integer"
-            },
-            "error-count": {
-                "type": "integer"
-            },
-            "error": {
-                "type": "boolean"
-            },
-            "gateway-latency-ms": {
-                "type": "integer"
-            }
-            <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
         },
-        "dynamic_templates": [
-            {
-                "strings_as_keywords": {
-                    "path_match": "custom.*",
-                    "match_mapping_type": "string",
-                    "mapping": {
-                        "type": "keyword"
+        "mappings": {
+            "properties": {
+                "gateway": {
+                    "type": "keyword"
+                },
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api-id": {
+                    "type": "keyword"
+                },
+                "request-id": {
+                    "type": "keyword"
+                },
+                "client-identifier": {
+                    "type": "keyword"
+                },
+                "correlation-id": {
+                    "type": "keyword"
+                },
+                "parent-correlation-id": {
+                    "type": "keyword"
+                },
+                "operation": {
+                    "type": "keyword"
+                },
+                "connector-type": {
+                    "type": "keyword"
+                },
+                "connector-id": {
+                    "type": "keyword"
+                },
+                "content-length": {
+                    "type": "integer"
+                },
+                "count": {
+                    "type": "integer"
+                },
+                "error-count": {
+                    "type": "integer"
+                },
+                "error": {
+                    "type": "boolean"
+                },
+                "gateway-latency-ms": {
+                    "type": "integer"
+                }
+                <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keywords": {
+                        "path_match": "custom.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword"
+                        }
                     }
                 }
-            }
-        ]
+            ]
+        }
     }
 }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -1,193 +1,195 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
-        "index.number_of_shards":${numberOfShards},
-        "index.number_of_replicas":${numberOfReplicas},
-        "index.refresh_interval": "${refreshInterval}"
-        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
-    },
-    "mappings": {
-        "properties": {
-            "gateway": {
-                "type": "keyword"
-            },
-            "@timestamp": {
-                "type": "date"
-            },
-            "transaction-id": {
-                "type": "keyword"
-            },
-            "api-id": {
-                "type": "keyword"
-            },
-            "request-id": {
-                "type": "keyword"
-            },
-            "plan-id": {
-                "type": "keyword"
-            },
-            "application-id": {
-                "type": "keyword"
-            },
-            "subscription-id": {
-                "type": "keyword"
-            },
-            "client-identifier": {
-                "type": "keyword"
-            },
-            "tenant": {
-                "type": "keyword"
-            },
-            "zone": {
-                "type": "keyword"
-            },
-            "http-method": {
-                "type": "short"
-            },
-            "local-address": {
-                "type": "keyword",
-                "index": false
-            },
-            "remote-address": {
-                "type": "ip"
-            },
-            "host": {
-                "type": "keyword"
-            },
-            "uri": {
-                "type": "keyword"
-            },
-            "path": {
-                "type": "keyword"
-            },
-            "mapped-path": {
-                "type": "keyword"
-            },
-            "user-agent": {
-                "type": "keyword"
-            },
-            "user_agent": {
-                "properties": {
-                    "device": {
-                        "properties": {
-                            "name": {
-                                "type": "keyword"
-                            }
-                        }
-                    },
-                    "name": {
-                        "type": "keyword",
-                        "index": true
-                    },
-                    "original": {
-                        "type": "text"
-                    },
-                    "os": {
-                        "properties": {
-                            "full": {
-                                "type": "text"
-                            },
-                            "name": {
-                                "type": "keyword",
-                                "index": true
-                            },
-                            "version": {
-                                "type": "keyword",
-                                "index": true
-                            }
-                        }
-                    },
-                    "os_name": {
-                        "type": "keyword",
-                        "index": true
-                    },
-                    "version": {
-                        "type": "text"
-                    }
-                }
-            },
-            "request-content-length": {
-                "type": "integer",
-                "index": false
-            },
-            "request-ended": {
-                "type": "boolean"
-            },
-            "endpoint": {
-                "type": "keyword"
-            },
-            "endpoint-response-time-ms": {
-                "type": "long"
-            },
-            "status": {
-                "type": "short"
-            },
-            "response-content-length": {
-                "type": "integer",
-                "index": false
-            },
-            "gateway-latency-ms": {
-                "type": "integer"
-            },
-            "gateway-response-time-ms": {
-                "type": "integer"
-            },
-            "geoip" : {
-                "properties": {
-                    "continent_name":{
-                        "type": "keyword",
-                        "index": true
-                    },
-                    "country_iso_code":{
-                        "type": "keyword",
-                        "index": true
-                    },
-                    "region_name":{
-                        "type": "keyword",
-                        "index": true
-                    },
-                    "city_name":{
-                        "type": "keyword",
-                        "index": true
-                    },
-                    "location": {
-                        "type": "geo_point"
-                    }
-                }
-            },
-            "user": {
-                "type": "keyword"
-            },
-            "security-type": {
-                "type": "keyword",
-                "index": true
-            },
-            "security-token": {
-                "type": "keyword",
-                "index": true
-            },
-            "error-message": {
-                "type": "text"
-            },
-            "error-key": {
-                "type": "keyword",
-                "index": true
-            }
-            <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+    "template": {
+        "settings": {
+            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            "index.number_of_shards":${numberOfShards},
+            "index.number_of_replicas":${numberOfReplicas},
+            "index.refresh_interval": "${refreshInterval}"
+            <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
         },
-        "dynamic_templates": [
-            {
-                "strings_as_keywords": {
-                    "path_match": "custom.*",
-                    "match_mapping_type": "string",
-                    "mapping": {
-                        "type": "keyword"
+        "mappings": {
+            "properties": {
+                "gateway": {
+                    "type": "keyword"
+                },
+                "@timestamp": {
+                    "type": "date"
+                },
+                "transaction-id": {
+                    "type": "keyword"
+                },
+                "api-id": {
+                    "type": "keyword"
+                },
+                "request-id": {
+                    "type": "keyword"
+                },
+                "plan-id": {
+                    "type": "keyword"
+                },
+                "application-id": {
+                    "type": "keyword"
+                },
+                "subscription-id": {
+                    "type": "keyword"
+                },
+                "client-identifier": {
+                    "type": "keyword"
+                },
+                "tenant": {
+                    "type": "keyword"
+                },
+                "zone": {
+                    "type": "keyword"
+                },
+                "http-method": {
+                    "type": "short"
+                },
+                "local-address": {
+                    "type": "keyword",
+                    "index": false
+                },
+                "remote-address": {
+                    "type": "ip"
+                },
+                "host": {
+                    "type": "keyword"
+                },
+                "uri": {
+                    "type": "keyword"
+                },
+                "path": {
+                    "type": "keyword"
+                },
+                "mapped-path": {
+                    "type": "keyword"
+                },
+                "user-agent": {
+                    "type": "keyword"
+                },
+                "user_agent": {
+                    "properties": {
+                        "device": {
+                            "properties": {
+                                "name": {
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "original": {
+                            "type": "text"
+                        },
+                        "os": {
+                            "properties": {
+                                "full": {
+                                    "type": "text"
+                                },
+                                "name": {
+                                    "type": "keyword",
+                                    "index": true
+                                },
+                                "version": {
+                                    "type": "keyword",
+                                    "index": true
+                                }
+                            }
+                        },
+                        "os_name": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "version": {
+                            "type": "text"
+                        }
+                    }
+                },
+                "request-content-length": {
+                    "type": "integer",
+                    "index": false
+                },
+                "request-ended": {
+                    "type": "boolean"
+                },
+                "endpoint": {
+                    "type": "keyword"
+                },
+                "endpoint-response-time-ms": {
+                    "type": "long"
+                },
+                "status": {
+                    "type": "short"
+                },
+                "response-content-length": {
+                    "type": "integer",
+                    "index": false
+                },
+                "gateway-latency-ms": {
+                    "type": "integer"
+                },
+                "gateway-response-time-ms": {
+                    "type": "integer"
+                },
+                "geoip" : {
+                    "properties": {
+                        "continent_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "country_iso_code":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "region_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "city_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "location": {
+                            "type": "geo_point"
+                        }
+                    }
+                },
+                "user": {
+                    "type": "keyword"
+                },
+                "security-type": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "security-token": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "error-message": {
+                    "type": "text"
+                },
+                "error-key": {
+                    "type": "keyword",
+                    "index": true
+                }
+                <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keywords": {
+                        "path_match": "custom.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword"
+                        }
                     }
                 }
-            }
-        ]
+            ]
+        }
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3014

**Description**

For ES8, we are now using "new" index template format instead of "legacy" one. 

It's ok for both cases on a fresh installation or an existing one. New templates will be create and ES will use them instead of legacy one.

**Additional context**

Require https://github.com/gravitee-io/gravitee-common-elasticsearch/pull/203
<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0-apim3014-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.1.0-apim3014-SNAPSHOT/gravitee-reporter-elasticsearch-5.1.0-apim3014-SNAPSHOT.zip)
  <!-- Version placeholder end -->
