### PR TITLE
chore: update renovate configuration to enable automerge on some dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,25 @@
 {
-    "extends": ["config:base", "schedule:earlyMondays"],
-    "prConcurrentLimit": 3,
-    "rebaseWhen": "conflicted"
+    "extends": ["config:base", ":label(dependencies)"],
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "chore"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["major"],
+            "semanticCommitType": "chore"
+        }
+    ]
 }


### PR DESCRIPTION
**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.1.0/gravitee-reporter-elasticsearch-5.1.0.zip)
  <!-- Version placeholder end -->
