### PR TITLE
fix: handle null client response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>6.0.24</gravitee-bom.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
-        <gravitee-reporter-common.version>1.0.4</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.0.5</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.2</gravitee-node-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3770

**Description**

Client response can be null when log configuration is Request only. In v3 engine, an object with only the status was reported all the time. However, In v4 engine emulation, there is no object.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.2-apim3770-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.1.2-apim3770-SNAPSHOT/gravitee-reporter-elasticsearch-5.1.2-apim3770-SNAPSHOT.zip)
  <!-- Version placeholder end -->
