### PR TITLE
fix: bump reporter-common for Monitor issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>6.0.35</gravitee-bom.version>
         <gravitee-common.version>3.4.1</gravitee-common.version>
-        <gravitee-reporter-common.version>1.0.5</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.0.6</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.3</gravitee-node-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4083
https://github.com/gravitee-io/issues/issues/9589

**Description**

Bump reporter-common to fix Monitor issue
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.3-apim-4083-use-right-monitor-class-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.1.3-apim-4083-use-right-monitor-class-SNAPSHOT/gravitee-reporter-elasticsearch-5.1.3-apim-4083-use-right-monitor-class-SNAPSHOT.zip)
  <!-- Version placeholder end -->
