### PR TITLE
feat: report entrypoint id in v4 metrics index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
     <properties>
         <gravitee-bom.version>6.0.44</gravitee-bom.version>
         <gravitee-common.version>3.4.1</gravitee-common.version>
-        <gravitee-reporter-common.version>1.0.6</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.1.0</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.5</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.28.1</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.29.0</gravitee-reporter-api.version>
         <commons-validator.version>1.7</commons-validator.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <log4j-core.version>2.19.0</log4j-core.version>

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -116,6 +116,9 @@
             "request-ended": {
                 "type": "boolean"
             },
+            "entrypoint-id": {
+                "type": "keyword"
+            },
             "endpoint": {
                 "type": "keyword"
             },

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -117,6 +117,9 @@
                 "request-ended": {
                     "type": "boolean"
                 },
+                "entrypoint-id": {
+                    "type": "keyword"
+                },
                 "endpoint": {
                     "type": "keyword"
                 },


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-3481

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.2.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.2.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT/gravitee-reporter-elasticsearch-5.2.0-apim-3481-add-entrypoint-id-to-metrics-v4-SNAPSHOT.zip)
  <!-- Version placeholder end -->
