### PR TITLE
feat: Show API name in reporters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
     <properties>
         <gravitee-bom.version>6.0.47</gravitee-bom.version>
         <gravitee-common.version>3.4.1</gravitee-common.version>
-        <gravitee-reporter-common.version>1.2.2</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.3.0</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.30.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.31.0</gravitee-reporter-api.version>
         <commons-validator.version>1.7</commons-validator.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <log4j-core.version>2.19.0</log4j-core.version>

--- a/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
@@ -14,6 +14,9 @@
                 "api": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "available": {
                     "type": "boolean",
                     "index": false

--- a/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -30,6 +30,9 @@
                 "api": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "client-request": {
                     "type": "object",
                     "properties": {

--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -17,6 +17,9 @@
                 "api": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "api-response-time": {
                     "type": "long"
                 },

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
@@ -17,6 +17,9 @@
             "api-id": {
                 "type": "keyword"
             },
+            "api-name": {
+                "type": "keyword"
+            },
             "request-id": {
                 "type": "keyword"
             },

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
@@ -17,6 +17,9 @@
             "api-id": {
                 "type": "keyword"
             },
+            "api-name": {
+                "type": "keyword"
+            },
             "request-id": {
                 "type": "keyword"
             },

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -20,6 +20,9 @@
             "api-id": {
                 "type": "keyword"
             },
+            "api-name": {
+                "type": "keyword"
+            },
             "request-id": {
                 "type": "keyword"
             },

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -23,6 +23,9 @@
             "api-id": {
                 "type": "keyword"
             },
+            "api-name": {
+                "type": "keyword"
+            },
             "request-id": {
                 "type": "keyword"
             },

--- a/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
@@ -15,6 +15,9 @@
                 "api": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "available": {
                     "type": "boolean",
                     "index": false

--- a/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
@@ -31,6 +31,9 @@
                 "api": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "client-request": {
                     "type": "object",
                     "properties": {

--- a/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -18,6 +18,9 @@
                 "api": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "api-response-time": {
                     "type": "long"
                 },

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
@@ -31,6 +31,9 @@
                 "api-id": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "request-id": {
                     "type": "keyword"
                 },

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
@@ -31,6 +31,9 @@
                 "api-id": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "request-id": {
                     "type": "keyword"
                 },

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
@@ -21,6 +21,9 @@
                 "api-id": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "request-id": {
                     "type": "keyword"
                 },

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -24,6 +24,9 @@
                 "api-id": {
                     "type": "keyword"
                 },
+                "api-name": {
+                    "type": "keyword"
+                },
                 "request-id": {
                     "type": "keyword"
                 },


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-3932

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.4.0-apim-3932-Show-API-name-in-reporters-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.4.0-apim-3932-Show-API-name-in-reporters-SNAPSHOT/gravitee-reporter-elasticsearch-5.4.0-apim-3932-Show-API-name-in-reporters-SNAPSHOT.zip)
  <!-- Version placeholder end -->
