### PR TITLE
fix: add missing comma in policy template

### DIFF
--- a/src/main/resources/freemarker/os/policies/index-policy.ftl
+++ b/src/main/resources/freemarker/os/policies/index-policy.ftl
@@ -10,7 +10,7 @@
         "actions": [
           {
             "rollover": {
-              <#if indexLifecycleMinIndexAge??>"min_index_age": "${indexLifecycleMinIndexAge}"</#if>
+              <#if indexLifecycleMinIndexAge??>"min_index_age": "${indexLifecycleMinIndexAge}",</#if>
               "min_size": "${indexLifecycleMinSize}"
             }
           }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Before merging my last PR I have squashed all the commits to have a single fix commit. I have lost the comma in the template when I resolved the conflicts. Here is a PR to fix it.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.3.5-apim-7236-os-ism-53x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.3.5-apim-7236-os-ism-53x-SNAPSHOT/gravitee-reporter-elasticsearch-5.3.5-apim-7236-os-ism-53x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
