### PR TITLE
fix: use index state management policy id and rollover alias properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-common.version>3.4.1</gravitee-common.version>
         <gravitee-reporter-common.version>1.3.0</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>5.1.2</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
@@ -207,6 +207,12 @@ public class ReporterConfiguration {
     private String indexLifecyclePolicyPropertyName;
 
     /**
+     * Rollover name Property name
+     */
+    @Value("${reporters.elasticsearch.lifecycle.rollover_alias_property_name:index.lifecycle.rollover_alias}")
+    private String indexLifecycleRolloverAliasPropertyName;
+
+    /**
      * Extended settings template
      */
     @Value("${reporters.elasticsearch.template_mapping.extended_settings:#{null}}")
@@ -536,5 +542,13 @@ public class ReporterConfiguration {
         }
 
         return properties;
+    }
+
+    public String getIndexLifecycleRolloverAliasPropertyName() {
+        return indexLifecycleRolloverAliasPropertyName;
+    }
+
+    public void setIndexLifecycleRolloverAliasPropertyName(String indexLifecycleRolloverAliasPropertyName) {
+        this.indexLifecycleRolloverAliasPropertyName = indexLifecycleRolloverAliasPropertyName;
     }
 }

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/AbstractIndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/AbstractIndexPreparer.java
@@ -50,6 +50,7 @@ public abstract class AbstractIndexPreparer implements IndexPreparer {
         data.put("numberOfReplicas", this.configuration.getNumberOfReplicas());
         data.put("refreshInterval", this.configuration.getRefreshInterval());
         data.put("indexLifecyclePolicyPropertyName", this.configuration.getIndexLifecyclePolicyPropertyName());
+        data.put("indexLifecycleRolloverAliasPropertyName", this.configuration.getIndexLifecycleRolloverAliasPropertyName());
         data.put("indexLifecyclePolicyHealth", this.configuration.getIndexLifecyclePolicyHealth());
         data.put("indexLifecyclePolicyMonitor", this.configuration.getIndexLifecyclePolicyMonitor());
         data.put("indexLifecyclePolicyRequest", this.configuration.getIndexLifecyclePolicyRequest());

--- a/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-        <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyHealth??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-        <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyMonitor??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -3,7 +3,7 @@
     "index_patterns": ["${indexName}*"],
     "settings": {
         <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7236

**Description**

Follow up of this PR https://gravitee.atlassian.net/browse/APIM-7236
It's a simple cherry pick without any conflict to be able to apply the changes on APIM 4.5.x and master

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
