### PR TITLE
fix: bump gravitee-reporter-common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-common.version>3.4.1</gravitee-common.version>
-        <gravitee-reporter-common.version>1.3.0</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.3.1</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.1.2</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-7146

**Description**

bump gravitee-reporter-common version

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.5.2-APIM-7146-bump-gravitee-reporter-common-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.5.2-APIM-7146-bump-gravitee-reporter-common-SNAPSHOT/gravitee-reporter-elasticsearch-5.5.2-APIM-7146-bump-gravitee-reporter-common-SNAPSHOT.zip)
  <!-- Version placeholder end -->
