### PR TITLE
fix: ensure to get version 1.32.3 of gravitee-reporter-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,8 @@
     <properties>
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.7.4</gravitee-apim.version>
-        <gravitee-reporter-common.version>1.5.1</gravitee-reporter-common.version>
+        <gravitee-reporter-api.version>1.32.3</gravitee-reporter-api.version>
+        <gravitee-reporter-common.version>1.5.2</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.2.0</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
         <commons-validator.version>1.7</commons-validator.version>
@@ -103,6 +104,7 @@
         <dependency>
             <groupId>io.gravitee.reporter</groupId>
             <artifactId>gravitee-reporter-api</artifactId>
+            <version>${gravitee-reporter-api.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
**Issue**

APIM-9340

**Description**
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.8.1-fix-9340-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.8.1-fix-9340-SNAPSHOT/gravitee-reporter-elasticsearch-5.8.1-fix-9340-SNAPSHOT.zip)
  <!-- Version placeholder end -->
