### PR TITLE
fix: rename policy metric to additional metric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <properties>
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.7.4</gravitee-apim.version>
-        <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>
-        <gravitee-reporter-common.version>1.6.0</gravitee-reporter-common.version>
+        <gravitee-reporter-api.version>1.34.0</gravitee-reporter-api.version>
+        <gravitee-reporter-common.version>1.6.2</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.2.0</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
         <commons-validator.version>1.7</commons-validator.version>

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -202,7 +202,7 @@
             },
             {
                 "additional_long_metrics": {
-                    "path_match": "policy-metrics.long_*",
+                    "path_match": "additional-metrics.long_*",
                     "match_mapping_type": "long",
                     "mapping": {
                         "type": "long"
@@ -211,7 +211,7 @@
             },
             {
                 "additional_keyword_metrics": {
-                    "path_match": "policy-metrics.keyword_*",
+                    "path_match": "additional-metrics.keyword_*",
                     "match_mapping_type": "string",
                     "mapping": {
                         "type": "keyword"
@@ -219,8 +219,8 @@
                 }
             },
             {
-                "policies_boolean_metrics": {
-                    "path_match": "policy-metrics.bool_*",
+                "additional_boolean_metrics": {
+                    "path_match": "additional-metrics.bool_*",
                     "mapping": {
                         "type": "boolean"
                     }
@@ -228,7 +228,7 @@
             },
             {
                 "additional_double_metrics": {
-                    "path_match": "policy-metrics.double_*",
+                    "path_match": "additional-metrics.double_*",
                     "mapping": {
                         "type": "double"
                     }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -202,8 +202,8 @@
                     }
                 },
                 {
-                    "policies_long_metrics": {
-                        "path_match": "policy-metrics.long_*",
+                    "additional_long_metrics": {
+                        "path_match": "additional-metrics.long_*",
                         "match_mapping_type": "long",
                         "mapping": {
                             "type": "long"
@@ -212,7 +212,7 @@
                 },
                 {
                     "additional_keyword_metrics": {
-                        "path_match": "policy-metrics.keyword_*",
+                        "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
                             "type": "keyword"
@@ -220,8 +220,8 @@
                     }
                 },
                 {
-                    "policies_boolean_metrics": {
-                        "path_match": "policy-metrics.bool_*",
+                    "additional_boolean_metrics": {
+                        "path_match": "additional-metrics.bool_*",
                         "mapping": {
                             "type": "boolean"
                         }
@@ -229,7 +229,7 @@
                 },
                 {
                     "additional_double_metrics": {
-                        "path_match": "policy-metrics.double_*",
+                        "path_match": "additional-metrics.double_*",
                         "mapping": {
                             "type": "double"
                         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9748

**Description**
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.9.2-apim-9748-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.9.2-apim-9748-SNAPSHOT/gravitee-reporter-elasticsearch-5.9.2-apim-9748-SNAPSHOT.zip)
  <!-- Version placeholder end -->
