### PR TITLE
Support additional metrics

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,7 @@ This reporter writes access logs to an Elasticsearch instance
 |===
 |Plugin version    | APIM version       | ES version    | JDK version
 
+| 6.x              | 4.8.x              | 7.x and later | 17
 | 5.x              | 4.0.x              | 7.x and later | 17
 | 4.x              | 3.20.x to 4.0.x    | 5.x and later | 11
 | 3.x              | 3.18.x to 3.19.x   | 5.x to 7.x    | 8

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
     <properties>
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
-        <gravitee-apim.version>4.7.6</gravitee-apim.version>
-        <gravitee-reporter-common.version>1.5.2</gravitee-reporter-common.version>
+        <gravitee-apim.version>4.8.0-alpha.2</gravitee-apim.version>
+        <gravitee-reporter-common.version>1.6.2</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.2.0</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -199,6 +199,40 @@
                         "type": "keyword"
                     }
                 }
+            },
+            {
+                "additional_long_metrics": {
+                    "path_match": "additional-metrics.long_*",
+                    "match_mapping_type": "long",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "additional_keyword_metrics": {
+                    "path_match": "additional-metrics.keyword_*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            },
+            {
+                "additional_boolean_metrics": {
+                    "path_match": "additional-metrics.bool_*",
+                    "mapping": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "additional_double_metrics": {
+                    "path_match": "additional-metrics.double_*",
+                    "mapping": {
+                        "type": "double"
+                    }
+                }
             }
         ]
     }

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -200,6 +200,40 @@
                             "type": "keyword"
                         }
                     }
+                },
+                {
+                    "additional_long_metrics": {
+                        "path_match": "additional-metrics.long_*",
+                        "match_mapping_type": "long",
+                        "mapping": {
+                            "type": "long"
+                        }
+                    }
+                },
+                {
+                    "additional_keyword_metrics": {
+                        "path_match": "additional-metrics.keyword_*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                {
+                    "additional_boolean_metrics": {
+                        "path_match": "additional-metrics.bool_*",
+                        "mapping": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "additional_double_metrics": {
+                        "path_match": "additional-metrics.double_*",
+                        "mapping": {
+                            "type": "double"
+                        }
+                    }
                 }
             ]
         }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Support additional metrics
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-additional-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.0.0-additional-metrics-SNAPSHOT/gravitee-reporter-elasticsearch-6.0.0-additional-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
