### PR TITLE
feat: add an index template for v4 native event metrics

### DIFF
--- a/src/main/resources/freemarker/es8x/mapping/index-template-event-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-event-metrics.ftl
@@ -1,0 +1,90 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["event-metrics*"],
+    "data_stream": {},
+    "template": {
+        "settings": {
+            "index.mode": "time_series",
+            "index.lifecycle.name": "event-metrics-ilm-policy"
+        },
+        "mappings": {
+            "properties": {
+                "gw-id": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "org-id": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "env-id": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "api-id": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "plan-id": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "app-id": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "topic": {
+                    "type": "keyword",
+                    "time_series_dimension": true
+                },
+                "downstream-publish-messages-total": {
+                    "type": "integer",
+                    "time_series_metric": "counter"
+                },
+                "downstream-publish-message-bytes": {
+                    "type": "long",
+                    "time_series_metric": "counter"
+                },
+                "upstream-publish-messages-total": {
+                    "type": "integer",
+                    "time_series_metric": "counter"
+                },
+                "upstream-publish-message-bytes": {
+                    "type": "long",
+                    "time_series_metric": "counter"
+                },
+                "downstream-subscribe-messages-total": {
+                    "type": "integer",
+                    "time_series_metric": "counter"
+                },
+                "downstream-subscribe-message-bytes": {
+                    "type": "long",
+                    "time_series_metric": "counter"
+                },
+                "upstream-subscribe-messages-total": {
+                    "type": "integer",
+                    "time_series_metric": "counter"
+                },
+                "upstream-subscribe-message-bytes": {
+                    "type": "long",
+                    "time_series_metric": "counter"
+                },
+                "downstream-active-connections": {
+                    "type": "integer",
+                    "time_series_metric": "gauge"
+                },
+                "upstream-active-connections": {
+                    "type": "integer",
+                    "time_series_metric": "gauge"
+                },
+                "@timestamp": {
+                    "type": "date"
+                }
+            }
+        }
+    },
+    "priority": 9344593,
+    "_meta": {
+        "description": "Template for event metrics time series data stream"
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

Added an index template to create v4 event native metrics time series index.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.1.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT/gravitee-reporter-elasticsearch-6.1.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
