### PR TITLE
feat: add an index template for v4 native event metrics in ES7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.9.0-SNAPSHOT</gravitee-apim.version>
         <gravitee-reporter-common.version>1.7.0-alpha.3</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.3.0-alpha.1</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.3.0-alpha.2</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 
         <commons-validator.version>1.7</commons-validator.version>
@@ -187,6 +187,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
@@ -1,0 +1,88 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["event-metrics*"],
+    "data_stream": {},
+    "settings": {
+        "index.mode": "time_series",
+        "index.lifecycle.name": "event-metrics-ilm-policy"
+    },
+    "mappings": {
+        "properties": {
+            "gw-id": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "org-id": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "env-id": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "api-id": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "plan-id": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "app-id": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "topic": {
+                "type": "keyword",
+                "time_series_dimension": true
+            },
+            "downstream-publish-messages-total": {
+                "type": "integer",
+                "time_series_metric": "counter"
+            },
+            "downstream-publish-message-bytes": {
+                "type": "long",
+                "time_series_metric": "counter"
+            },
+            "upstream-publish-messages-total": {
+                "type": "integer",
+                "time_series_metric": "counter"
+            },
+            "upstream-publish-message-bytes": {
+                "type": "long",
+                "time_series_metric": "counter"
+            },
+            "downstream-subscribe-messages-total": {
+                "type": "integer",
+                "time_series_metric": "counter"
+            },
+            "downstream-subscribe-message-bytes": {
+                "type": "long",
+                "time_series_metric": "counter"
+            },
+            "upstream-subscribe-messages-total": {
+                "type": "integer",
+                "time_series_metric": "counter"
+            },
+            "upstream-subscribe-message-bytes": {
+                "type": "long",
+                "time_series_metric": "counter"
+            },
+            "downstream-active-connections": {
+                "type": "integer",
+                "time_series_metric": "gauge"
+            },
+            "upstream-active-connections": {
+                "type": "integer",
+                "time_series_metric": "gauge"
+            },
+            "@timestamp": {
+                "type": "date"
+            }
+        }
+    },
+    "priority": 9344,
+    "_meta": {
+        "description": "Template for event metrics time series data stream"
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

Added update template for ES7 index.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.2.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT/gravitee-reporter-elasticsearch-6.2.0-apim-10024-adapt-elasticsearch-reporter-to-handle-native-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
