### PR TITLE
feat: update index pattern in event metrics templates

### DIFF
--- a/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["event-metrics*"],
+    "index_patterns": ["${indexName}*"],
     "data_stream": {},
     "settings": {
         "index.mode": "time_series",

--- a/src/main/resources/freemarker/es8x/mapping/index-template-event-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-event-metrics.ftl
@@ -1,6 +1,6 @@
 <#ftl output_format="JSON">
 {
-    "index_patterns": ["event-metrics*"],
+    "index_patterns": ["${indexName}*"],
     "data_stream": {},
     "template": {
         "settings": {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024

**Description**

The ILM was not getting applied to the ES indices with the earlier index pattern. That is why it is replaced.