### PR TITLE
fix: bump gravitee-reporter-common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.3.0</version>
+        <version>22.5.1</version>
     </parent>
 
     <groupId>io.gravitee.reporter</groupId>
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.8.0-alpha.2</gravitee-apim.version>
-        <gravitee-reporter-common.version>1.6.2</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.6.3</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.2.0</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-10459

**Description**

bump report-common version

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.1-APIM-10459-fix-unable-to-access-401-logs-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.0.1-APIM-10459-fix-unable-to-access-401-logs-SNAPSHOT/gravitee-reporter-elasticsearch-6.0.1-APIM-10459-fix-unable-to-access-401-logs-SNAPSHOT.zip)
  <!-- Version placeholder end -->
