### PR TITLE
feat: prepare index as data stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.9.0-SNAPSHOT</gravitee-apim.version>
         <gravitee-reporter-common.version>1.7.0-alpha.7</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.3.0-alpha.2</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.3.0-alpha.3</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 
         <commons-validator.version>1.7</commons-validator.version>

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es7/ES7IndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es7/ES7IndexPreparer.java
@@ -53,6 +53,7 @@ public class ES7IndexPreparer extends AbstractIndexPreparer {
     protected Function<Type, CompletableSource> indexTypeMapper() {
         return type -> {
             final String typeName = type.getType();
+            boolean dataStream = type.isDataStream();
             final String templateName = configuration.getIndexName() + '-' + typeName;
             final String aliasName = configuration.getIndexName() + '-' + typeName;
 
@@ -62,8 +63,12 @@ public class ES7IndexPreparer extends AbstractIndexPreparer {
             data.put("indexName", configuration.getIndexName() + '-' + typeName);
 
             final String template = freeMarkerComponent.generateFromTemplate("/es7x/mapping/index-template-" + typeName + ".ftl", data);
-
             final Completable templateCreationCompletable = client.putTemplate(templateName, template);
+
+            if (dataStream) {
+                return client.getDataStream(templateName).switchIfEmpty(client.createDataStream(templateName).toMaybe()).ignoreElement();
+            }
+
             if (configuration.isIlmManagedIndex()) {
                 return templateCreationCompletable.andThen(ensureAlias(aliasName));
             }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10629

**Description**

Prepare index as data stream when metrics are to be saved as time series data stream.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.0-apim-10629-error-when-starting-a-fresh-gateway-environment-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.2.0-apim-10629-error-when-starting-a-fresh-gateway-environment-SNAPSHOT/gravitee-reporter-elasticsearch-6.2.0-apim-10629-error-when-starting-a-fresh-gateway-environment-SNAPSHOT.zip)
  <!-- Version placeholder end -->
