### PR TITLE
feat: exclude creating index alias when using data streams

### DIFF
--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es7/ES7IndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es7/ES7IndexPreparer.java
@@ -65,11 +65,7 @@ public class ES7IndexPreparer extends AbstractIndexPreparer {
             final String template = freeMarkerComponent.generateFromTemplate("/es7x/mapping/index-template-" + typeName + ".ftl", data);
             final Completable templateCreationCompletable = client.putTemplate(templateName, template);
 
-            if (dataStream) {
-                return client.getDataStream(templateName).switchIfEmpty(client.createDataStream(templateName).toMaybe()).ignoreElement();
-            }
-
-            if (configuration.isIlmManagedIndex()) {
+            if (configuration.isIlmManagedIndex() && !dataStream) {
                 return templateCreationCompletable.andThen(ensureAlias(aliasName));
             }
             return templateCreationCompletable;

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es8/ES8IndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/es8/ES8IndexPreparer.java
@@ -65,11 +65,7 @@ public class ES8IndexPreparer extends AbstractIndexPreparer {
             final String template = freeMarkerComponent.generateFromTemplate("/es8x/mapping/index-template-" + typeName + ".ftl", data);
             final Completable templateCreationCompletable = client.putIndexTemplate(templateName, template);
 
-            if (dataStream) {
-                return client.getDataStream(templateName).switchIfEmpty(client.createDataStream(templateName).toMaybe()).ignoreElement();
-            }
-
-            if (configuration.isIlmManagedIndex()) {
+            if (configuration.isIlmManagedIndex() && !dataStream) {
                 return templateCreationCompletable.andThen(ensureAlias(aliasName));
             }
             return templateCreationCompletable;


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10629

**Description**

These changes will exclude creation of an index alias when we use data streams.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.0-apim-10629-error-when-starting-a-fresh-gateway-environment-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.2.0-apim-10629-error-when-starting-a-fresh-gateway-environment-SNAPSHOT/gravitee-reporter-elasticsearch-6.2.0-apim-10629-error-when-starting-a-fresh-gateway-environment-SNAPSHOT.zip)
  <!-- Version placeholder end -->
