### PR TITLE
chore: bump gravitee-common-elasticsearch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.9.0-SNAPSHOT</gravitee-apim.version>
         <gravitee-reporter-common.version>1.7.0-alpha.7</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.3.0-alpha.3</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.3.0-alpha.4</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 
         <commons-validator.version>1.7</commons-validator.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10629

**Description**

bump gravitee-common-elasticsearch version to 6.3.0-alpha.4

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
