### PR TITLE
fix: bump gravitee-reporter-common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>8.2.22</gravitee-bom.version>
         <gravitee-apim.version>4.9.0-SNAPSHOT</gravitee-apim.version>
-        <gravitee-reporter-common.version>1.7.0-alpha.7</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.7.0-alpha.8</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.3.0-alpha.5</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-10943

**Description**

bump reporter-common

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.0-APIM-10943-bump-reporter-common-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.2.0-APIM-10943-bump-reporter-common-SNAPSHOT/gravitee-reporter-elasticsearch-6.2.0-APIM-10943-bump-reporter-common-SNAPSHOT.zip)
  <!-- Version placeholder end -->
