### PR TITLE
bump gravitee-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.8.0
+    gravitee: gravitee-io/gravitee@4.16.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)


### PR DESCRIPTION
**Description**

Use latest version of gravitee-orb
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.3`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.0.3/gravitee-reporter-elasticsearch-6.0.3.zip)
  <!-- Version placeholder end -->
