### PR TITLE
fix: failed repository tests on ES7x

### DIFF
--- a/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
@@ -1,9 +1,7 @@
 <#ftl output_format="JSON">
 {
     "index_patterns": ["${indexName}*"],
-    "data_stream": {},
     "settings": {
-        "index.mode": "time_series",
         "index.lifecycle.name": "event-metrics-ilm-policy"
     },
     "mappings": {
@@ -104,9 +102,5 @@
                 "type": "date"
             }
         }
-    },
-    "priority": 9344,
-    "_meta": {
-        "description": "Template for event metrics time series data stream"
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Fixed failing repository tests on Elasticsearch version 7x due to template misconfiguration.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
