### PR TITLE
fix: adapt opensearch for event-metrics

### DIFF
--- a/src/main/java/io/gravitee/reporter/elasticsearch/factory/opensearch/OpenSearchBeanFactory.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/factory/opensearch/OpenSearchBeanFactory.java
@@ -26,6 +26,7 @@ import io.gravitee.reporter.elasticsearch.indexer.PerTypeAndDateIndexNameGenerat
 import io.gravitee.reporter.elasticsearch.indexer.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.IndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+import io.gravitee.reporter.elasticsearch.mapping.opensearch.OpenSearchIndexPreparer;
 import lombok.NoArgsConstructor;
 
 /**
@@ -54,6 +55,6 @@ public class OpenSearchBeanFactory implements BeanFactory {
         final FreeMarkerComponent freeMarkerComponent,
         final Client client
     ) {
-        return new ES7IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client);
+        return new OpenSearchIndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client);
     }
 }

--- a/src/main/java/io/gravitee/reporter/elasticsearch/mapping/opensearch/OpenSearchIndexPreparer.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/mapping/opensearch/OpenSearchIndexPreparer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.mapping.opensearch;
+
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.reporter.elasticsearch.mapping.AbstractIndexPreparer;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.CompletableSource;
+import io.reactivex.rxjava3.functions.Function;
+import java.util.Collections;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class OpenSearchIndexPreparer extends AbstractIndexPreparer {
+
+    public OpenSearchIndexPreparer(
+        final ReporterConfiguration configuration,
+        final PipelineConfiguration pipelineConfiguration,
+        final FreeMarkerComponent freeMarkerComponent,
+        final Client client
+    ) {
+        super(configuration, pipelineConfiguration, freeMarkerComponent, client);
+    }
+
+    @Override
+    public Completable prepare() {
+        return indexMapping().andThen(pipeline());
+    }
+
+    @Override
+    protected Function<Type, CompletableSource> indexTypeMapper() {
+        return type -> {
+            final String typeName = type.getType();
+            boolean dataStream = type.isDataStream();
+            final String templateName = configuration.getIndexName() + '-' + typeName;
+            final String aliasName = configuration.getIndexName() + '-' + typeName;
+
+            log.debug("Trying to put template mapping for type[{}] name[{}]", typeName, templateName);
+
+            Map<String, Object> data = getTemplateData();
+            data.put("indexName", configuration.getIndexName() + '-' + typeName);
+
+            final String template = freeMarkerComponent.generateFromTemplate(
+                "/opensearch/mapping/index-template-" + typeName + ".ftl",
+                data
+            );
+            final Completable templateCreationCompletable;
+            if (type.isDataStream()) {
+                templateCreationCompletable = client.putIndexTemplate(templateName, template);
+            } else {
+                templateCreationCompletable = client.putTemplate(templateName, template);
+            }
+
+            if (configuration.isIlmManagedIndex() && !dataStream) {
+                return templateCreationCompletable.andThen(ensureAlias(aliasName));
+            }
+            return templateCreationCompletable;
+        };
+    }
+
+    private Completable ensureAlias(String aliasName) {
+        final String aliasTemplate = freeMarkerComponent.generateFromTemplate(
+            "/opensearch/alias/alias.ftl",
+            Collections.singletonMap("aliasName", aliasName)
+        );
+
+        return client
+            .getAlias(aliasName)
+            .switchIfEmpty(client.createIndexWithAlias(aliasName + "-000001", aliasTemplate).toMaybe())
+            .ignoreElement();
+    }
+}

--- a/src/main/resources/freemarker/opensearch/alias/alias.ftl
+++ b/src/main/resources/freemarker/opensearch/alias/alias.ftl
@@ -1,0 +1,9 @@
+<@compress single_line=true>
+{
+    "aliases": {
+        "${aliasName}": {
+            "is_write_index": true
+        }
+    }
+}
+</@compress>

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-event-metrics.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-event-metrics.ftl
@@ -1,0 +1,9 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "data_stream": {},
+    "priority": 9344593,
+    "_meta": {
+        "description": "Template for event metrics time series data stream"
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-health.ftl
@@ -1,0 +1,50 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
+        <#if indexLifecyclePolicyHealth??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "api": {
+                    "type": "keyword"
+                },
+                "api-name": {
+                    "type": "keyword"
+                },
+                "available": {
+                    "type": "boolean",
+                    "index": false
+                },
+                "endpoint": {
+                    "type": "keyword"
+                },
+                "gateway": {
+                    "type": "keyword"
+                },
+                "response-time": {
+                    "type": "integer"
+                },
+                "state": {
+                    "type": "integer",
+                    "index": false
+                },
+                "transition": {
+                    "type": "boolean"
+                },
+                "steps": {
+                    "type": "object",
+                    "enabled": false
+                },
+                "success": {
+                    "type": "boolean",
+                    "index": true
+                }
+            }
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
@@ -1,0 +1,90 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if !(extendedSettingsTemplate.analysis)??>,
+        "analysis": {
+            "analyzer": {
+                "gravitee_body_analyzer": {
+                    "type": "custom",
+                    "tokenizer": "whitespace",
+                    "filter": [
+                        "lowercase"
+                    ]
+                }
+            }
+        }
+        </#if>
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api": {
+                    "type": "keyword"
+                },
+                "api-name": {
+                    "type": "keyword"
+                },
+                "client-request": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "client-response": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "proxy-request": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "proxy-response": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text",
+                            "analyzer": "gravitee_body_analyzer"
+                        },
+                        "headers": {
+                            "enabled":  false,
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-monitor.ftl
@@ -1,0 +1,43 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
+        <#if indexLifecyclePolicyMonitor??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "os": {
+                    "properties": {
+                        "cpu": {
+                            "properties": {
+                                "load_average": {
+                                    "properties": {
+                                        "1m": {
+                                            "type": "float"
+                                        },
+                                        "5m": {
+                                            "type": "float"
+                                        },
+                                        "15m": {
+                                            "type": "float"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "gateway": {
+                    "type": "keyword"
+                },
+                "hostname": {
+                    "type": "keyword"
+                }
+            }
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
@@ -1,0 +1,215 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api": {
+                    "type": "keyword"
+                },
+                "api-name": {
+                    "type": "keyword"
+                },
+                "api-response-time": {
+                    "type": "long"
+                },
+                "application": {
+                    "type": "keyword"
+                },
+                "endpoint": {
+                    "type": "keyword"
+                },
+                "gateway": {
+                    "type": "keyword"
+                },
+                "local-address": {
+                    "type": "keyword",
+                    "index": false
+                },
+                "message": {
+                    "type": "text"
+                },
+                "method": {
+                    "type": "short"
+                },
+                "plan": {
+                    "type": "keyword"
+                },
+                "proxy-latency": {
+                    "type": "integer"
+                },
+                "remote-address": {
+                    "type": "ip"
+                },
+                "geoip" : {
+                    "properties": {
+                        "continent_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "country_iso_code":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "region_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "city_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "location": {
+                            "type": "geo_point"
+                        }
+                    }
+                },
+                "request-content-length": {
+                    "type": "integer",
+                    "index": false
+                },
+                "response-content-length": {
+                    "type": "integer",
+                    "index": false
+                },
+                "response-time": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "short"
+                },
+                "tenant": {
+                    "type": "keyword"
+                },
+                "transaction": {
+                    "type": "keyword"
+                },
+                "uri": {
+                    "type": "keyword"
+                },
+                "path": {
+                    "type": "keyword"
+                },
+                "mapped-path": {
+                    "type": "keyword"
+                },
+                "host": {
+                    "type": "keyword"
+                },
+                "user-agent": {
+                    "type": "keyword"
+                },
+                "user_agent": {
+                    "properties": {
+                        "device": {
+                            "properties": {
+                                "name": {
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "original": {
+                            "type": "text"
+                        },
+                        "os": {
+                            "properties": {
+                                "full": {
+                                    "type": "text"
+                                },
+                                "name": {
+                                    "type": "keyword",
+                                    "index": true
+                                },
+                                "version": {
+                                    "type": "keyword",
+                                    "index": true
+                                }
+                            }
+                        },
+                        "os_name": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "version": {
+                            "type": "text"
+                        }
+                    }
+                },
+                "user": {
+                    "type": "keyword"
+                },
+                "security-type": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "security-token": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "error-key": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "error-component-type": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "error-component-name": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "subscription": {
+                    "type": "keyword"
+                },
+                "zone": {
+                    "type": "keyword"
+                },
+                "warnings": {
+                    "type": "nested",
+                    "properties": {
+                        "key": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "message": {
+                            "type": "text"
+                        },
+                        "component-type": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "component-name": {
+                            "type": "keyword",
+                            "index": true
+                        }
+                    }
+                }
+                <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keywords": {
+                        "path_match": "custom.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            ]
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
@@ -1,0 +1,82 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "api-name": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "request-ended": {
+                "type": "boolean"
+            },
+            "entrypoint-request": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers":  {
+                       "enabled":  false,
+                       "type": "object"
+                   }
+                }
+            },
+            "entrypoint-response": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers":  {
+                       "enabled":  false,
+                       "type": "object"
+                   }
+                }
+            },
+            "endpoint-request": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers":  {
+                       "enabled":  false,
+                       "type": "object"
+                   }
+                }
+            },
+            "endpoint-response": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers": {
+                        "enabled":  false,
+                        "type": "object"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
@@ -1,0 +1,68 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "api-name": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "correlation-id": {
+                "type": "keyword"
+            },
+            "parent-correlation-id": {
+                "type": "keyword"
+            },
+            "operation": {
+                "type": "keyword"
+            },
+            "connector-type": {
+                "type": "keyword"
+            },
+            "connector-id": {
+                "type": "keyword"
+            },
+            "message": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "keyword"
+                    },
+                    "payload":{
+                        "type": "text"
+                    },
+                    "headers":{
+                        "enabled": false,
+                        "type": "object"
+                    },
+                    "metadata":  {
+                       "enabled": false,
+                       "type": "object"
+                    },
+                    "error":  {
+                        "type": "boolean"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
@@ -1,0 +1,82 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "gateway": {
+                "type": "keyword"
+            },
+            "@timestamp": {
+                "type": "date"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "api-name": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "correlation-id": {
+                "type": "keyword"
+            },
+            "parent-correlation-id": {
+                "type": "keyword"
+            },
+            "operation": {
+                "type": "keyword"
+            },
+            "connector-type": {
+                "type": "keyword"
+            },
+            "connector-id": {
+                "type": "keyword"
+            },
+            "content-length": {
+                "type": "integer"
+            },
+            "count": {
+                "type": "integer"
+            },
+            "error-count": {
+                "type": "integer"
+            },
+            "count-increment": {
+                "type": "integer"
+            },
+            "error-count-increment": {
+                "type": "integer"
+            },
+            "error": {
+                "type": "boolean"
+            },
+            "gateway-latency-ms": {
+                "type": "integer"
+            }
+            <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+        },
+        "dynamic_templates": [
+            {
+                "strings_as_keywords": {
+                    "path_match": "custom.*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
@@ -1,0 +1,267 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "gateway": {
+                "type": "keyword"
+            },
+            "@timestamp": {
+                "type": "date"
+            },
+            "transaction-id": {
+                "type": "keyword"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "api-name": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "plan-id": {
+                "type": "keyword"
+            },
+            "application-id": {
+                "type": "keyword"
+            },
+            "subscription-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "tenant": {
+                "type": "keyword"
+            },
+            "zone": {
+                "type": "keyword"
+            },
+            "http-method": {
+                "type": "short"
+            },
+            "local-address": {
+                "type": "keyword",
+                "index": false
+            },
+            "remote-address": {
+                "type": "ip"
+            },
+            "host": {
+                "type": "keyword"
+            },
+            "uri": {
+                "type": "keyword"
+            },
+            "path": {
+                "type": "keyword"
+            },
+            "mapped-path": {
+                "type": "keyword"
+            },
+            "user-agent": {
+                "type": "keyword"
+            },
+            "user_agent": {
+                "properties": {
+                    "device": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "name": {
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "original": {
+                        "type": "text"
+                    },
+                    "os": {
+                        "properties": {
+                            "full": {
+                                "type": "text"
+                            },
+                            "name": {
+                                "type": "keyword",
+                                "index": true
+                            },
+                            "version": {
+                                "type": "keyword",
+                                "index": true
+                            }
+                        }
+                    },
+                    "os_name": {
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "version": {
+                        "type": "text"
+                    }
+                }
+            },
+            "request-content-length": {
+                "type": "integer",
+                "index": false
+            },
+            "request-ended": {
+                "type": "boolean"
+            },
+            "entrypoint-id": {
+                "type": "keyword"
+            },
+            "endpoint": {
+                "type": "keyword"
+            },
+            "endpoint-response-time-ms": {
+                "type": "long"
+            },
+            "status": {
+                "type": "short"
+            },
+            "response-content-length": {
+                "type": "integer",
+                "index": false
+            },
+            "gateway-latency-ms": {
+                "type": "integer"
+            },
+            "gateway-response-time-ms": {
+                "type": "integer"
+            },
+            "ai-input-token": {
+                "type": "integer"
+            },
+            "ai-output-token": {
+                "type": "integer"
+            },
+            "geoip" : {
+                "properties": {
+                    "continent_name":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "country_iso_code":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "region_name":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "city_name":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "location": {
+                        "type": "geo_point"
+                    }
+                }
+            },
+            "user": {
+                "type": "keyword"
+            },
+            "security-type": {
+                "type": "keyword",
+                "index": true
+            },
+            "security-token": {
+                "type": "keyword",
+                "index": true
+            },
+            "error-message": {
+                "type": "text"
+            },
+            "error-key": {
+                "type": "keyword",
+                "index": true
+            },
+            "error-component-type": {
+                "type": "keyword",
+                "index": true
+            },
+            "error-component-name": {
+                "type": "keyword",
+                "index": true
+            },
+            "warnings": {
+                "type": "nested",
+                "properties": {
+                    "key": {
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "message": {
+                        "type": "text"
+                    },
+                    "component-type": {
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "component-name": {
+                        "type": "keyword",
+                        "index": true
+                    }
+                }
+            }
+            <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+        },
+        "dynamic_templates": [
+            {
+                "strings_as_keywords": {
+                    "path_match": "custom.*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            },
+            {
+                "additional_long_metrics": {
+                    "path_match": "additional-metrics.long_*",
+                    "match_mapping_type": "long",
+                    "mapping": {
+                        "type": "long"
+                    }
+                }
+            },
+            {
+                "additional_keyword_metrics": {
+                    "path_match": "additional-metrics.keyword_*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            },
+            {
+                "additional_boolean_metrics": {
+                    "path_match": "additional-metrics.bool_*",
+                    "mapping": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "additional_double_metrics": {
+                    "path_match": "additional-metrics.double_*",
+                    "mapping": {
+                        "type": "double"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/test/java/io/gravitee/reporter/elasticsearch/factory/BeanFactoryBuilderTest.java
+++ b/src/test/java/io/gravitee/reporter/elasticsearch/factory/BeanFactoryBuilderTest.java
@@ -31,6 +31,7 @@ import io.gravitee.reporter.elasticsearch.indexer.PerTypeAndDateIndexNameGenerat
 import io.gravitee.reporter.elasticsearch.indexer.PerTypeIndexNameGenerator;
 import io.gravitee.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
 import io.gravitee.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+import io.gravitee.reporter.elasticsearch.mapping.opensearch.OpenSearchIndexPreparer;
 import io.reactivex.rxjava3.core.Single;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -125,7 +126,8 @@ class BeanFactoryBuilderTest {
 
             assertThat(beanFactory).isNotNull();
             assertThat(beanFactory.createIndexNameGenerator(reporterConfiguration)).isInstanceOf(PerTypeAndDateIndexNameGenerator.class);
-            assertThat(beanFactory.createIndexPreparer(reporterConfiguration, null, null, null)).isInstanceOf(ES7IndexPreparer.class);
+            assertThat(beanFactory.createIndexPreparer(reporterConfiguration, null, null, null))
+                .isInstanceOf(OpenSearchIndexPreparer.class);
         }
 
         @DisplayName("should instantiate beans for OpenSearch ilm mode")
@@ -140,7 +142,8 @@ class BeanFactoryBuilderTest {
 
             assertThat(beanFactory).isNotNull();
             assertThat(beanFactory.createIndexNameGenerator(reporterConfiguration)).isInstanceOf(PerTypeIndexNameGenerator.class);
-            assertThat(beanFactory.createIndexPreparer(reporterConfiguration, null, null, null)).isInstanceOf(ES7IndexPreparer.class);
+            assertThat(beanFactory.createIndexPreparer(reporterConfiguration, null, null, null))
+                .isInstanceOf(OpenSearchIndexPreparer.class);
         }
     }
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

Opensearch support data-streams but it's quite different from ES.
It requires a specific index-template and does not use the same API resource to create it.

That's why we need a dedicated index preparer for OpenSeach.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.1-adapt-opensearch-for-event-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.2.1-adapt-opensearch-for-event-metrics-SNAPSHOT/gravitee-reporter-elasticsearch-6.2.1-adapt-opensearch-for-event-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
