### PR TITLE
fix: Elastic Index Error in V2 and V4 http proxy

### DIFF
--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -75,11 +75,11 @@
                     }
                 },
                 "request-content-length": {
-                    "type": "integer",
+                    "type": "long",
                     "index": false
                 },
                 "response-content-length": {
-                    "type": "integer",
+                    "type": "long",
                     "index": false
                 },
                 "response-time": {

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -113,7 +113,7 @@
                 }
             },
             "request-content-length": {
-                "type": "integer",
+                "type": "long",
                 "index": false
             },
             "request-ended": {
@@ -132,7 +132,7 @@
                 "type": "short"
             },
             "response-content-length": {
-                "type": "integer",
+                "type": "long",
                 "index": false
             },
             "gateway-latency-ms": {

--- a/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -76,11 +76,11 @@
                     }
                 },
                 "request-content-length": {
-                    "type": "integer",
+                    "type": "long",
                     "index": false
                 },
                 "response-content-length": {
-                    "type": "integer",
+                    "type": "long",
                     "index": false
                 },
                 "response-time": {

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -114,7 +114,7 @@
                     }
                 },
                 "request-content-length": {
-                    "type": "integer",
+                    "type": "long",
                     "index": false
                 },
                 "request-ended": {
@@ -133,7 +133,7 @@
                     "type": "short"
                 },
                 "response-content-length": {
-                    "type": "integer",
+                    "type": "long",
                     "index": false
                 },
                 "gateway-latency-ms": {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.3-APIM-11027-es-indexing-error-bp-6-2-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.2.3-APIM-11027-es-indexing-error-bp-6-2-SNAPSHOT/gravitee-reporter-elasticsearch-6.2.3-APIM-11027-es-indexing-error-bp-6-2-SNAPSHOT.zip)
  <!-- Version placeholder end -->
