### PR TITLE
update readme with versioning and compatibility info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,16 @@ https://github.com/gravitee-io/issues/issues/XXXXX
 
 A small description of what you did in that PR.
 
+> [!WARNING]
+> Major version 7.x is the latest version available for this repository.
+> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
+>
+> ⚠️**No new major version should be released.**
+>
+> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
+>
+> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-elasticsearch` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+
 **Additional context**
 
 <!-- Add any other context about the PR here -->

--- a/README.adoc
+++ b/README.adoc
@@ -8,6 +8,17 @@ image:https://circleci.com/gh/gravitee-io/gravitee-reporter-elasticsearch.svg?st
 image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
 endif::[]
 
+[WARNING]
+====
+Major version 7.x is the latest version available for this repository.
+
+⚠️**No new major version should be released.**
+
+Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+ 
+As a consequence, **all bug fixes** that are merged into `gravitee-reporter-elasticsearch` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).
+====
+
 
 == Presentation
 
@@ -18,9 +29,7 @@ This reporter writes access logs to an Elasticsearch instance
 
 |===
 |Plugin version    | APIM version       | ES version    | JDK version
-
-| 7.x              | 4.10.x              | 7.x and later | 17
-
+| 7.x              | 4.10.x             | 7.x and later | 17
 | 6.x              | 4.8.x              | 7.x and later | 17
 | 5.x              | 4.0.x              | 7.x and later | 17
 | 4.x              | 3.20.x to 4.0.x    | 5.x and later | 11


### PR DESCRIPTION
Starting with APIM 4.11.0, reporter-common, reporter-file and reporter-elasticsearch have been added as maven module in apim monorepo.

This PR updates the README to add a warning about that change.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.4.2`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/7.4.2/gravitee-reporter-elasticsearch-7.4.2.zip)
  <!-- Version placeholder end -->
