### PR TITLE
fix: defer pipeline setup so reporter recovers when ES is available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-apim.version>4.10.0-alpha.4</gravitee-apim.version>
         <gravitee-reporter-common.version>2.0.0</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.3.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.5.1</gravitee-common-elasticsearch.version>
         <commons-validator.version>1.10.0</commons-validator.version>
         <testcontainers.version>1.21.4</testcontainers.version>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12615
https://gravitee.atlassian.net/browse/APIM-12887

**Description**

Defer pipeline setup so reporter recovers when ES is available.

> [!WARNING]
> Major version 7.x is the latest version available for this repository.
> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
>
> ⚠️**No new major version should be released.**
>
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
>
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-elasticsearch` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.4.2`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/7.4.2/gravitee-reporter-elasticsearch-7.4.2.zip)
  <!-- Version placeholder end -->
