### PR TITLE
chore: bump common elasticsearch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-apim.version>4.9.0</gravitee-apim.version>
         <gravitee-reporter-common.version>1.9.2</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.3.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.5.1</gravitee-common-elasticsearch.version>
         <commons-validator.version>1.10.0</commons-validator.version>
         <testcontainers.version>1.21.3</testcontainers.version>
 


### PR DESCRIPTION
**Description**

Bump common es.

> [!WARNING]
> Major version 7.x is the latest version available for this repository.
> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
>
> ⚠️**No new major version should be released.**
>
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
>
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-elasticsearch` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.3.4-APIM-12651-bump-common-es-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.3.4-APIM-12651-bump-common-es-SNAPSHOT/gravitee-reporter-elasticsearch-6.3.4-APIM-12651-bump-common-es-SNAPSHOT.zip)
  <!-- Version placeholder end -->
