### PR TITLE
fix(deps): bump common elasticsearch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-apim.version>4.8.3</gravitee-apim.version>
         <gravitee-reporter-common.version>1.6.8</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.2.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.5.1</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 
         <commons-validator.version>1.10.0</commons-validator.version>


### PR DESCRIPTION
**Description**

Bump common es and add vertx-web-client test dep.

> [!WARNING]
> Major version 7.x is the latest version available for this repository.
> It is used by the latest versions of `gravitee-reporter-***` plugins that are compatible with APIM 4.10.
>
> ⚠️**No new major version should be released.**
>
> Starting with APIM 4.11.0, `gravitee-reporter-common`, `gravitee-reporter-elasticsearch` and `gravitee-reporter-file` have been added as maven modules in the APIM monorepo.
>
> As a consequence, **all bug fixes** that are merged into `gravitee-reporter-elasticsearch` have to be cherry-picked in the [APIM monorepo](https://github.com/gravitee-io/gravitee-api-management).

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.9-APIM-12651-bump-common-es-6-0-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.0.9-APIM-12651-bump-common-es-6-0-x-SNAPSHOT/gravitee-reporter-elasticsearch-6.0.9-APIM-12651-bump-common-es-6-0-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
