### PR TITLE
fix: bump reporter-common - 5.5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-bom.version>6.0.60</gravitee-bom.version>
         <gravitee-common.version>3.4.1</gravitee-common.version>
-        <gravitee-reporter-common.version>1.3.4</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.3.5</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>5.1.2</gravitee-common-elasticsearch.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12149

**Description**

bump reporter-common
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.5.7-APIM-12149-404-Not-Found-Analytics-5-5-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/5.5.7-APIM-12149-404-Not-Found-Analytics-5-5-x-SNAPSHOT/gravitee-reporter-elasticsearch-5.5.7-APIM-12149-404-Not-Found-Analytics-5-5-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
