### PR TITLE
fix: bump reporter-common - 6.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <gravitee-apim.version>4.8.3</gravitee-apim.version>
-        <gravitee-reporter-common.version>1.6.8</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>1.6.9</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.2.1</gravitee-common-elasticsearch.version>
         <gravitee-node-api.version>4.8.7</gravitee-node-api.version>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12149

**Description**

bump reporter-common
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.11-APIM-12149-404-Not-Found-Analytics-6-0-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.0.11-APIM-12149-404-Not-Found-Analytics-6-0-x-SNAPSHOT/gravitee-reporter-elasticsearch-6.0.11-APIM-12149-404-Not-Found-Analytics-6-0-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
