### PR TITLE
fix: bump reporter-common to 2.0.2 to fix msgpack security vulnerability (APIM-12726)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <gravitee-apim.version>4.11.4</gravitee-apim.version>
-        <gravitee-reporter-common.version>2.0.1</gravitee-reporter-common.version>
+        <gravitee-reporter-common.version>2.0.2</gravitee-reporter-common.version>
         <gravitee-common-elasticsearch.version>6.6.0</gravitee-common-elasticsearch.version>
         <commons-validator.version>1.10.0</commons-validator.version>
         <testcontainers.version>1.21.4</testcontainers.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12726

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.4.6-fix-apim-12726-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/7.4.6-fix-apim-12726-master-SNAPSHOT/gravitee-reporter-elasticsearch-7.4.6-fix-apim-12726-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
