### PR TITLE
fix(reporter): drop event-metrics ILM literal and honor lifecycle overrides

### DIFF
--- a/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
+++ b/src/main/java/io/gravitee/reporter/elasticsearch/config/ReporterConfiguration.java
@@ -38,6 +38,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 public class ReporterConfiguration {
 
     private static final String DEFAULT_ELASTICSEARCH_ENDPOINT = "http://localhost:9200";
+    public static final String DEFAULT_INDEX_LIFECYCLE_POLICY_PROPERTY_NAME = "index.lifecycle.name";
+    public static final String DEFAULT_INDEX_LIFECYCLE_ROLLOVER_ALIAS_PROPERTY_NAME = "index.lifecycle.rollover_alias";
 
     @Autowired
     private ConfigurableEnvironment environment;
@@ -204,14 +206,14 @@ public class ReporterConfiguration {
     /**
      * Policy name Property name
      */
-    @Value("${reporters.elasticsearch.lifecycle.policy_property_name:index.lifecycle.name}")
-    private String indexLifecyclePolicyPropertyName;
+    @Value("${reporters.elasticsearch.lifecycle.policy_property_name:" + DEFAULT_INDEX_LIFECYCLE_POLICY_PROPERTY_NAME + "}")
+    private String indexLifecyclePolicyPropertyName = DEFAULT_INDEX_LIFECYCLE_POLICY_PROPERTY_NAME;
 
     /**
      * Rollover name Property name
      */
-    @Value("${reporters.elasticsearch.lifecycle.rollover_alias_property_name:index.lifecycle.rollover_alias}")
-    private String indexLifecycleRolloverAliasPropertyName;
+    @Value("${reporters.elasticsearch.lifecycle.rollover_alias_property_name:" + DEFAULT_INDEX_LIFECYCLE_ROLLOVER_ALIAS_PROPERTY_NAME + "}")
+    private String indexLifecycleRolloverAliasPropertyName = DEFAULT_INDEX_LIFECYCLE_ROLLOVER_ALIAS_PROPERTY_NAME;
 
     /**
      * Extended settings template
@@ -431,7 +433,7 @@ public class ReporterConfiguration {
     }
 
     public String getIndexLifecyclePolicyPropertyName() {
-        return indexLifecyclePolicyPropertyName;
+        return blankToDefault(indexLifecyclePolicyPropertyName, DEFAULT_INDEX_LIFECYCLE_POLICY_PROPERTY_NAME);
     }
 
     public void setIndexLifecyclePolicyPropertyName(String indexLifecyclePolicyPropertyName) {
@@ -550,10 +552,29 @@ public class ReporterConfiguration {
     }
 
     public String getIndexLifecycleRolloverAliasPropertyName() {
-        return indexLifecycleRolloverAliasPropertyName;
+        return blankToDefault(indexLifecycleRolloverAliasPropertyName, DEFAULT_INDEX_LIFECYCLE_ROLLOVER_ALIAS_PROPERTY_NAME);
     }
 
     public void setIndexLifecycleRolloverAliasPropertyName(String indexLifecycleRolloverAliasPropertyName) {
         this.indexLifecycleRolloverAliasPropertyName = indexLifecycleRolloverAliasPropertyName;
+    }
+
+    /**
+     * Spring's {@code ${property:default}} only falls back when the property is absent: a property that is
+     * present but empty — {@code rollover_alias_property_name:} in YAML, an empty environment variable, or a
+     * blank Helm value — resolves to an empty string and skips the default. An empty settings key makes the
+     * cluster reject the whole index template, taking the shard, replica and refresh settings down with it,
+     * so treat blank as unset. Surrounding whitespace is stripped for the same reason: a quoted YAML value,
+     * a Helm value or an environment variable can carry it, and a padded key is rejected just like an empty
+     * one. Only the property <em>names</em> are normalised — a blank policy already means "no lifecycle for
+     * this type", and a whitespace-only policy is an ordinary typo the cluster reports through its own
+     * lifecycle explain API.
+     */
+    private static String blankToDefault(String value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        final String stripped = value.strip();
+        return stripped.isEmpty() ? defaultValue : stripped;
     }
 }

--- a/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-        <#if indexLifecyclePolicyHealth??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+        <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+        <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-            <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-            <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-health.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-            <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-monitor.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-            <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-request.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-v4-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-health.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-        <#if indexLifecyclePolicyHealth??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+        <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-monitor.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+        <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/src/test/java/io/gravitee/reporter/elasticsearch/mapping/IndexTemplateTest.java
+++ b/src/test/java/io/gravitee/reporter/elasticsearch/mapping/IndexTemplateTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.reporter.elasticsearch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Asserts what the index templates actually render: the configured lifecycle property names when they are
+ * overridden, the Elasticsearch defaults when they are blank, and JSON-safe output when a name or policy is
+ * malformed. Runs without the container {@code ElasticsearchReporterTest} needs.
+ *
+ * <p>Templates are rendered directly rather than through a preparer's {@code indexTypeMapper()}, because that
+ * method also performs the HTTP PUT. The model still comes from the real {@link AbstractIndexPreparer}, so the
+ * wiring between configuration and template stays under test.
+ */
+class IndexTemplateTest {
+
+    /**
+     * Every template that can render lifecycle settings. event-metrics is excluded: it hardcodes its policy
+     * and takes no configuration, which is tracked separately.
+     */
+    static Stream<Arguments> trees_and_lifecycle_templates() {
+        return Stream.of("es7x", "es8x", "es9x", "opensearch").flatMap(esDir ->
+            Stream.of("request", "health", "monitor", "log", "v4-log", "v4-metrics", "v4-message-log", "v4-message-metrics").map(template ->
+                Arguments.of(esDir, template)
+            )
+        );
+    }
+
+    @ParameterizedTest(name = "{0} {1} template uses the configured ISM property names")
+    @MethodSource("trees_and_lifecycle_templates")
+    void should_render_configured_ism_property_names_instead_of_hardcoded_ilm_keys(String esDir, String template) {
+        var configuration = configurationWithPolicies();
+        configuration.setIndexLifecyclePolicyPropertyName("index.plugins.index_state_management.policy_id");
+        configuration.setIndexLifecycleRolloverAliasPropertyName("index.plugins.index_state_management.rollover_alias");
+
+        assertThat(render(esDir, template, configuration))
+            .contains("\"index.plugins.index_state_management.policy_id\"")
+            .contains("\"index.plugins.index_state_management.rollover_alias\"")
+            .doesNotContain("\"index.lifecycle.");
+    }
+
+    @ParameterizedTest(name = "{0} {1} template falls back to the default keys when property names are blank")
+    @MethodSource("trees_and_lifecycle_templates")
+    void should_fall_back_to_default_property_names_when_configured_blank(String esDir, String template) {
+        var configuration = configurationWithPolicies();
+        configuration.setIndexLifecyclePolicyPropertyName("");
+        configuration.setIndexLifecycleRolloverAliasPropertyName("  index.lifecycle.rollover_alias  ");
+
+        // An empty or padded key would make the cluster reject the whole template, taking the shard, replica
+        // and refresh settings down with it — blank has to mean "unset", not "render nothing at all".
+        assertThat(render(esDir, template, configuration))
+            .contains("\"index.lifecycle.name\"")
+            .contains("\"index.lifecycle.rollover_alias\"")
+            .doesNotContain("\"\":")
+            .doesNotContain("\"  index.lifecycle.rollover_alias  \"");
+    }
+
+    @Test
+    void should_render_default_ilm_keys_for_an_untouched_elasticsearch_configuration() {
+        assertThat(render("es8x", "log", configurationWithPolicies()))
+            .contains("\"index.lifecycle.name\": \"policy-log\"")
+            .contains("\"index.lifecycle.rollover_alias\"");
+    }
+
+    @Test
+    void should_escape_property_names_and_policies_so_a_malformed_one_cannot_break_the_json_body() {
+        var configuration = configurationWithPolicies();
+        configuration.setIndexLifecyclePolicyPropertyName("bad\"name");
+        configuration.setIndexLifecycleRolloverAliasPropertyName("bad\"alias");
+        configuration.setIndexLifecyclePolicyLog("bad\"policy");
+
+        assertThat(render("es8x", "log", configuration))
+            .contains("\"bad\\\"name\"")
+            .contains("\"bad\\\"alias\"")
+            .contains("\"bad\\\"policy\"");
+    }
+
+    private static ReporterConfiguration configurationWithPolicies() {
+        var configuration = new ReporterConfiguration();
+        // @Value defaults only apply under Spring and these fields have no initialisers, so a
+        // hand-built configuration must supply anything the templates interpolate unguarded.
+        configuration.setIndexName("gravitee");
+        configuration.setRefreshInterval("5s");
+        configuration.setNumberOfShards(1);
+        configuration.setNumberOfReplicas(1);
+        configuration.setIndexLifecyclePolicyHealth("policy-health");
+        configuration.setIndexLifecyclePolicyMonitor("policy-monitor");
+        configuration.setIndexLifecyclePolicyRequest("policy-request");
+        configuration.setIndexLifecyclePolicyLog("policy-log");
+        return configuration;
+    }
+
+    private static String render(String esDir, String template, ReporterConfiguration configuration) {
+        var freeMarkerComponent = FreeMarkerComponent.builder()
+            .classLoader(IndexTemplateTest.class.getClassLoader())
+            .classLoaderTemplateBase("freemarker")
+            .build();
+        var pipelineConfiguration = new PipelineConfiguration(null, null, freeMarkerComponent);
+
+        // getTemplateData() is shared by every preparer and carries no per-distribution state, so any one of
+        // them produces the model for all four template trees. No client: nothing here talks to a cluster.
+        var preparer = new ES8IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+        var data = preparer.getTemplateData();
+        data.put("indexName", configuration.getIndexName() + '-' + template);
+
+        return freeMarkerComponent.generateFromTemplate("/" + esDir + "/mapping/index-template-" + template + ".ftl", data);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-11655

**Description**

The `es8x`/`es9x` index templates hard-coded the Elasticsearch ILM rollover-alias key `index.lifecycle.rollover_alias` instead of the configured `reporters.elasticsearch.lifecycle.rollover_alias_property_name`. OpenSearch rejects an unknown index setting outright rather than ignoring it, so a deployment pointing the lifecycle keys at ISM failed index preparation at startup. The `es7x` and `opensearch` trees already used the override for both keys; only `es8x`/`es9x` were broken.

- Render the configured property names in the `es8x`/`es9x` templates.
- Guard the lifecycle block with `?has_content` instead of `??`, so a policy configured as an empty string renders no lifecycle block rather than an empty policy id that the cluster rejects.
- Treat a blank or padded property *name* as unset and fall back to the default. Spring's `${property:default}` only falls back when the property is absent, so a present-but-empty value resolves to an empty string and skips the default. That renders an empty settings key, which the cluster refuses along with the shard, replica and refresh settings in the same template. The two defaults are now named constants that also initialise their fields, so a configuration built outside Spring is no longer null.
- Escape the interpolated property names and policies with `?json_string`. The JSON output format does not escape interpolations, so a value containing a quote produced a malformed request body and an opaque parse error instead of a diagnosable unknown-setting response.

**Additional context**

- `IndexTemplateTest` (new, no container) asserts the rendered body across all four template trees for every lifecycle-capable type: configured property names when overridden, default ILM keys when blank or padded, and escaped output when a name or policy is malformed. 66 cases, 0.3s. Full module suite is 105/105 green.
- **event-metrics is deliberately untouched.** Its policy is hard-coded and takes no configuration on this line; making it configurable is tracked separately under APIM-14441. An earlier revision of this PR removed that policy, which would have silently dropped retention for existing ES7/ES8/ES9 users.
- The testcontainers bump is not housekeeping: 1.21.3 fails Docker environment detection on current Docker Desktop, so every container-backed test errors with `Could not find a valid Docker environment` before it starts. Verified on this branch — `ElasticsearchReporterTest` is 5 errors on 1.21.3 and 5 passes on 1.21.4, same daemon, nothing else changed.
- Serves APIM 4.9.x. The equivalent fix for 4.11.x/4.12.x and master is in the monorepo, [gravitee-api-management#17820](https://github.com/gravitee-io/gravitee-api-management/pull/17820). 4.10.x pins plugin 7.4.6, which has no maintenance branch yet.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.3.8-apim-11655-6-3-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.3.8-apim-11655-6-3-x-SNAPSHOT/gravitee-reporter-elasticsearch-6.3.8-apim-11655-6-3-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
