### PR TITLE
chore(deps): bump gravitee-common-elasticsearch version to 6.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <gravitee-apim.version>4.9.0</gravitee-apim.version>
         <gravitee-reporter-common.version>1.9.4</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.6.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.6.1</gravitee-common-elasticsearch.version>
         <commons-validator.version>1.10.0</commons-validator.version>
         <testcontainers.version>1.21.3</testcontainers.version>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/11916

**Description**

Upgrade `gravitee-common-elasticsearch` version to `6.6.1`.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.3.7`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/reporter/gravitee-reporter-elasticsearch/6.3.7/gravitee-reporter-elasticsearch-6.3.7.zip)
  <!-- Version placeholder end -->
